### PR TITLE
docs: one-line Start with R<n> relaunch chats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Do not implement optional/further-review items unless the spec assigns them. Sib
 
 The human prompt is one line: `Start with R2` or `Start with PR 3`. Do not expect base branch, fee model, or “don’t start the next item” in the prompt.
 
-1. Map the R-item to a PR in `IMPLEMENTATION_ORDER.md`. One chat = that PR only. Stop when the PR is open.
+1. Map the R-item to a PR in `IMPLEMENTATION_ORDER.md`. One chat = that PR only. Stop when the PR is open and README Status is updated. Remind the human of the next unassigned prompt.
 2. If `docs/relaunch/R<n>-*.md` is missing, copy `TASK_TEMPLATE.md`, fill it, and assign it in `docs/relaunch/README.md` **before** Solidity. You may read gitignored `.cursor/relaunch-plan.md` **only** to draft that one spec. Implement from the spec, never from the plan.
 3. Ask the human **only** the open product gates listed for that PR in `IMPLEMENTATION_ORDER.md` (and the spec’s **Open product decisions** section). If that list is empty, do not ask; implement. Do not ask fee / packing / pause / optional items unless that PR’s list names them.
 4. `git fetch`. Branch from `main` if no relaunch PR is open; otherwise from the latest open relaunch PR’s head (stack). Never implement on `main`. Branch **before** the first edit.
@@ -75,7 +75,7 @@ Do this even if a user-level rule says “don’t commit until asked.” An assi
 2. **Commit when the spec’s success criteria pass.** Small, targeted commits (spec/docs, then code, then follow-up docs). Subject: `type: why`.
 3. **Push and open a PR** with `.github/PULL_REQUEST_TEMPLATE.md`. Point at the spec. Do not commit `lib/` dirt from `make patch-deps`, secrets, or `.env`.
 4. **One implementer per PR.** Parallel review (Cursor/Codex/Claude/Bugbot) is expected. Parallel implementation on overlapping Solidity is not. Skip git worktrees for this relaunch except a docs-only PR that does not share files.
-5. After the PR is open, set `docs/relaunch/README.md` **Status** to this PR (link) and “next unassigned: …” so the following chat can stay one line. Do not start the next R-item in this chat. The human merges in order.
+5. After the PR is open, set `docs/relaunch/README.md` **Status** to this PR (full GitHub link) and “next unassigned: …” (the one-line prompt for the following chat). If the URL is only known after opening, add that Status update in a follow-up commit and push, then stop. Do not start the next R-item in this chat. The human merges in order. In the closing message, remind the human of that next prompt so they can spin up the following agent.
 
 ## PRs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,19 @@ Foundry Solidity repo for BitChill DCA-in contracts on Rootstock (`0.8.36`, EVM 
 
 1. This file.
 2. `docs/relaunch/IMPLEMENTATION_ORDER.md` when choosing the next relaunch PR or checking dependency gates.
-3. The assigned spec under `docs/relaunch/` (required before Solidity changes). `.cursor/relaunch-plan.md` is private planner notes — not a task list.
+3. The assigned spec under `docs/relaunch/` (required before Solidity changes).
 4. Start from the spec’s file list. Expand only through imports, inheritance, interfaces, mocks, failing tests, and compiler errors. Name extra files in the PR.
 
 Do not implement optional/further-review items unless the spec assigns them. Sibling repo `dca-out-contracts` is out of scope unless named.
+
+## Starting a relaunch chat
+
+The human prompt is one line: `Start with R2` or `Start with PR 3`. Do not expect base branch, fee model, or “don’t start the next item” in the prompt.
+
+1. Map the R-item to a PR in `IMPLEMENTATION_ORDER.md`. One chat = that PR only. Stop when the PR is open.
+2. If `docs/relaunch/R<n>-*.md` is missing, copy `TASK_TEMPLATE.md`, fill it, and assign it in `docs/relaunch/README.md` **before** Solidity. You may read gitignored `.cursor/relaunch-plan.md` **only** to draft that one spec. Implement from the spec, never from the plan.
+3. Ask the human **only** the open product gates listed for that PR in `IMPLEMENTATION_ORDER.md` (and the spec’s **Open product decisions** section). If that list is empty, do not ask; implement. Do not ask fee / packing / pause / optional items unless that PR’s list names them.
+4. `git fetch`. Branch from `main` if no relaunch PR is open; otherwise from the latest open relaunch PR’s head (stack). Never implement on `main`. Branch **before** the first edit.
 
 ## Layout
 
@@ -62,11 +71,11 @@ Unless the assigned spec explicitly changes one:
 
 Do this even if a user-level rule says “don’t commit until asked.” An assigned `docs/relaunch/` spec **is** authorization to branch, commit, push, and open a PR.
 
-1. **Branch before the first edit.** Never implement on `main`. `git checkout -b <type>/r<n>-<slug>` from `main` if the previous relaunch PR is merged, otherwise from that PR’s branch (stack).
-2. **Commit when the spec’s success criteria pass.** Small, targeted commits a reviewer can walk (spec/docs, then code, then follow-up docs). Subject line: `type: why`.
+1. **Branch before the first edit** (`git checkout -b <type>/r<n>-<slug>` from the base in **Starting a relaunch chat**).
+2. **Commit when the spec’s success criteria pass.** Small, targeted commits (spec/docs, then code, then follow-up docs). Subject: `type: why`.
 3. **Push and open a PR** with `.github/PULL_REQUEST_TEMPLATE.md`. Point at the spec. Do not commit `lib/` dirt from `make patch-deps`, secrets, or `.env`.
-4. **One implementer per PR.** Parallel Cursor/Codex/Claude **review** is expected. Parallel **implementation** on overlapping Solidity (`DcaManager`, handlers, `DcaDappTest`) is not. Git worktrees do not help that overlap; skip them for this relaunch except a docs-only PR.
-5. **Stack, merge in order.** Open PR N+1 based on PR N’s branch. The human merges one by one after review. Do not merge PR 3+ until the Rootstock compiler/EVM proof in `docs/relaunch/IMPLEMENTATION_ORDER.md` has passed (Anvil fork is not that proof).
+4. **One implementer per PR.** Parallel review (Cursor/Codex/Claude/Bugbot) is expected. Parallel implementation on overlapping Solidity is not. Skip git worktrees for this relaunch except a docs-only PR that does not share files.
+5. After the PR is open, set `docs/relaunch/README.md` **Status** to this PR (link) and “next unassigned: …” so the following chat can stay one line. Do not start the next R-item in this chat. The human merges in order.
 
 ## PRs
 

--- a/docs/relaunch/IMPLEMENTATION_ORDER.md
+++ b/docs/relaunch/IMPLEMENTATION_ORDER.md
@@ -7,7 +7,7 @@ Status: **planning guide**. Orders PRs. Not an implementation spec. Human prompt
 - One PR, one behavioral purpose. Bundle R-items only when this file says so.
 - Write `docs/relaunch/R<n>-...md` from `TASK_TEMPLATE.md` before Solidity. You may read `.cursor/relaunch-plan.md` only to draft that spec; implement from the spec.
 - Ask product questions only from the **Ask** column below. Empty Ask = do not ask; implement.
-- Branch before edits; stack on the latest open relaunch PR, else `main`. Commit, push, open the PR (`AGENTS.md`). Stop. Human merges in order.
+- Branch before edits; stack on the latest open relaunch PR, else `main`. Commit, push, open the PR (`AGENTS.md`). Update `docs/relaunch/README.md` **Status** with the PR link and next unassigned prompt (follow-up commit if the URL was unknown before open). Stop. Remind the human of that next prompt. Human merges in order.
 - Run targeted tests, then the `AGENTS.md` done-gate.
 - Do not `--broadcast`. Keep OpenZeppelin `v4.9.3` until an optional late upgrade PR.
 

--- a/docs/relaunch/IMPLEMENTATION_ORDER.md
+++ b/docs/relaunch/IMPLEMENTATION_ORDER.md
@@ -1,53 +1,58 @@
 # Relaunch implementation order
 
-Status: **planning guide**. This file orders the relaunch work. It is not an implementation spec.
-
-Agents should use this file to choose the next PR, then work only from the assigned `docs/relaunch/R<n>-<short-slug>.md` spec for that PR. Do not implement directly from `.cursor/relaunch-plan.md`.
+Status: **planning guide**. Orders PRs. Not an implementation spec. Human prompt: `Start with R<n>` (`AGENTS.md`).
 
 ## Ground rules
 
-- One PR should have one behavioral purpose. If two R-items share the same files and tests, bundle them only when this file says so.
-- Write or assign the specific `R<n>-...md` spec before implementation starts.
-- Branch before edits; commit, push, and open the PR when the spec’s success criteria pass (`AGENTS.md` Git section). Stack PR N+1 on PR N’s branch. Merge in order after review.
-- Run targeted tests first, then the repo done-gate from `AGENTS.md`.
-- Do not `--broadcast` or touch live contracts from implementation PRs.
-- Keep OpenZeppelin at `v4.9.3` during the main relaunch work. A major OpenZeppelin upgrade is optional late work.
+- One PR, one behavioral purpose. Bundle R-items only when this file says so.
+- Write `docs/relaunch/R<n>-...md` from `TASK_TEMPLATE.md` before Solidity. You may read `.cursor/relaunch-plan.md` only to draft that spec; implement from the spec.
+- Ask product questions only from the **Ask** column below. Empty Ask = do not ask; implement.
+- Branch before edits; stack on the latest open relaunch PR, else `main`. Commit, push, open the PR (`AGENTS.md`). Stop. Human merges in order.
+- Run targeted tests, then the `AGENTS.md` done-gate.
+- Do not `--broadcast`. Keep OpenZeppelin `v4.9.3` until an optional late upgrade PR.
 
 ## Rootstock compiler / EVM proof
 
-`forge test --fork-url` and Anvil copy Rootstock **state** but execute on **revm**. Passing fork tests does not mean Rootstock will accept 0.8.36 / `cancun` bytecode.
+**Passed (2026-08-15).** Rootstock testnet (chain 31) accepted first-party bytecode compiled with solc **0.8.36** / `cancun`. Blockscout verified `OperationsAdmin`, `DcaManager`, and `TropykusDocHandlerMoc` at those settings. Anvil/`forge test --fork-url` is still not rskj; this testnet tx is the consensus proof. PR 3+ may merge on this pin. Do not set `prague` / `osaka` / `amsterdam`. Do not use blob opcodes.
 
-Do this **after PR 1 is merged (or on that bytecode) and before merging PR 3** (first behavior change). Opening later PRs for review is fine; merging them on an unproven pin is how the whole stack would have to roll back.
+## Product gates (PR 2)
 
-1. Using `[profile.deploy]` (`0.8.36`, `cancun`, `via_ir`), deploy one first-party contract (e.g. `OperationsAdmin`) to Rootstock **testnet**. Human/ops runs the broadcast, not the implementation agent.
-2. The tx must succeed (the node accepted the code). Deployed bytecode must not start with `0xEF`.
-3. If Blockscout lists solc 0.8.36, verify with `cancun`. If it only lists 0.8.34, that is an explorer catalog limit, not a consensus cap — still confirm the **tx** succeeded.
-4. If the node rejects the tx, fall back to `shanghai` (PUSH0 only) or the portal-listed solc, still not `london` unless the node rejects shanghai. Land that fallback on the R23 branch **before** merging behavior PRs.
+Record these **before the first PR that changes fee logic, `DcaDetails`, handler per-user storage, or event ABI** (not before R2). If the human starts that later PR and PR 2 is not merged, ask **only** the gates that PR needs.
 
-Do not set `prague` / `osaka` / `amsterdam`. Do not use blob opcodes.
+- Fee model: keep linear / flatten to one rate / leave as-is for now.
+- R18 packing: skip / `DcaDetails` only / `DcaDetails` plus handler per-user state.
+- R19 pause: this relaunch or defer.
+- Optional: R12 compound, R13 admin, owner sweep, on-chain deposit pause.
 
-## Required decisions before code changes
-
-Decide these before the first PR that changes fee logic, `DcaDetails`, handler per-user storage, or event ABI:
-
-- Fee model: keep the linear decreasing fee, flatten to one rate, or leave as-is for now.
-- R18 packing: skip, `DcaDetails` only, or `DcaDetails` plus handler per-user state.
-- R19 pause: ship per-schedule pause in this relaunch or defer it.
-- Optional items: R12 compound interest, R13 admin model, handler owner sweep, on-chain deposit pause.
-
-Default if undecided:
-
-- Keep OpenZeppelin `v4.9.3`.
-- Skip storage packing, but still use `calldata` for handler batch arrays when those files are touched.
-- Defer R12, R13, R19, owner sweep, and on-chain deposit pause.
+Defaults if the human says “use defaults”: keep OZ `v4.9.3`; skip packing (still `calldata` on handler batch arrays); defer R12, R13, R19, owner sweep, deposit pause. Do not apply defaults unless they say so.
 
 ## PR order
 
+Ask = product questions for that PR only. `Start with R2` means PR 3.
+
+| Start with | PR | Ask |
+|---|---|---|
+| R23 | 1 (merged) | — |
+| PR 2, decision record | 2 | Fee model, R18, R19, optionals listed above |
+| R2 | 3 | none |
+| R7, R11, R14 | 4 | none |
+| R3, R4, R5 | 5 | Fee model if PR 2 did not record it |
+| R6, R17 | 6 | none |
+| R8 | 7 | none |
+| R1, R20 | 8 | none |
+| R15 | 9 | none |
+| R22 (folders) | 10 | none |
+| R22 (idle) | 11 | none |
+| R22 (LayerBank) | 12 | none |
+| R22 (deploy/CI) | 13 | none |
+| R9 | 14 | R18/R19 if not recorded (ABI freeze) |
+| R16 | 15 | none |
+| R10 | 16 | none |
+| R12, R13, R18, R19, OZ 5.x | optional late | only if the human named that item |
+
 ### PR 1 - R23 toolchain and dependency baseline
 
-Bump first-party Solidity and Rootstock EVM settings before other code changes. Pin latest stable `0.8.x` and `evm_version = "cancun"`. Anvil/fork tests are not the Rootstock proof — see [Rootstock compiler / EVM proof](#rootstock-compiler--evm-proof) before merging PR 3.
-
-Keep OpenZeppelin `v4.9.3`. Uniswap **sources** stay `=0.7.6` in git; they cannot be compiled with solc 0.7.6 while first-party Dex files import them (see R23). `make patch-deps` remains required. Do not include OpenZeppelin 5.x migration in this PR.
+**Merged.** First-party `0.8.36` / `cancun`. Uniswap git sources stay `=0.7.6`; `make patch-deps` remains required. OZ `v4.9.3`. Testnet proof passed.
 
 ### PR 2 - Decision record
 

--- a/docs/relaunch/R23-toolchain-baseline.md
+++ b/docs/relaunch/R23-toolchain-baseline.md
@@ -1,6 +1,6 @@
 # R23 — Toolchain and dependency baseline
 
-Status: **implemented — awaiting user confirmation** · Assigned: yes · Optional/further-review: no
+Status: **merged** (GitHub #42) · Assigned: no · Optional/further-review: no
 
 ## Objective
 

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -20,6 +20,6 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 
 ## Status
 
-- Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub #42). Rootstock testnet accepted solc 0.8.36 / `cancun`.
-- Assigned: none.
-- Next: the human names an R-item. Typical: PR 2 (decision record) or PR 3 / R2 (UTC period; no product gates). R2 does not wait on PR 2.
+- Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub [#42](https://github.com/BitChillRSK/dca-contracts/pull/42)). Rootstock testnet accepted solc 0.8.36 / `cancun`.
+- Assigned: docs hardening — GitHub [#43](https://github.com/BitChillRSK/dca-contracts/pull/43) (`docs/relaunch-short-agent-prompts`).
+- Next unassigned: `Start with R2` (PR 3, UTC purchase-period). No product gates. Does not wait on PR 2.

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -21,5 +21,5 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 ## Status
 
 - Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub [#42](https://github.com/BitChillRSK/dca-contracts/pull/42)). Rootstock testnet accepted solc 0.8.36 / `cancun`.
-- Assigned: docs hardening — GitHub [#43](https://github.com/BitChillRSK/dca-contracts/pull/43) (`docs/relaunch-short-agent-prompts`).
+- Assigned: none.
 - Next unassigned: `Start with R2` (PR 3, UTC purchase-period). No product gates. Does not wait on PR 2.

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -1,25 +1,25 @@
 # Relaunch task specs
 
-Committed work orders for BitChill contract PRs. Implement from a spec here, not from gitignored `.cursor/relaunch-plan.md`.
+Committed work orders for BitChill contract PRs. Implement from a spec here. The human prompt is `Start with R<n>` (see `AGENTS.md`).
 
 ## Progressive disclosure
 
 1. Root [`AGENTS.md`](../../AGENTS.md).
-2. **One** assigned spec in this folder.
-3. The files it names, then only imports / inheritance / mocks / failing tests / compiler errors.
+2. [`IMPLEMENTATION_ORDER.md`](./IMPLEMENTATION_ORDER.md) — PR map and which product gates to ask.
+3. **One** assigned spec in this folder (write it from [`TASK_TEMPLATE.md`](./TASK_TEMPLATE.md) if missing).
+4. The files it names, then only imports / inheritance / mocks / failing tests / compiler errors.
 
-Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`.
+Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. Do not implement from gitignored `.cursor/relaunch-plan.md` (read it only to draft the missing spec).
 
 ## How to add a spec
 
 1. Copy [`TASK_TEMPLATE.md`](./TASK_TEMPLATE.md) to `R<n>-<short-slug>.md`.
-2. Optional/further-review items get a spec only when explicitly assigned.
-3. One spec = one PR unless **Scope** names a tight bundle.
-
-## Planning docs
-
-- [`IMPLEMENTATION_ORDER.md`](./IMPLEMENTATION_ORDER.md) - agreed PR order, decision gates, and optional late work.
+2. Fill **Open product decisions** (or write **none**). Ask the human only if that section is not none and not yet answered.
+3. Optional/further-review items get a spec only when explicitly assigned.
+4. One spec = one PR unless **Scope** names a tight bundle.
 
 ## Status
 
-Assigned: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1). Implement that spec only.
+- Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub #42). Rootstock testnet accepted solc 0.8.36 / `cancun`.
+- Assigned: none.
+- Next: the human names an R-item. Typical: PR 2 (decision record) or PR 3 / R2 (UTC period; no product gates). R2 does not wait on PR 2.

--- a/docs/relaunch/TASK_TEMPLATE.md
+++ b/docs/relaunch/TASK_TEMPLATE.md
@@ -12,6 +12,10 @@ One or two sentences: what changes and why. The PR must be reviewable against th
 
 Only what the implementer needs (current bug, invariant, or product rule). Do not paste the private relaunch plan. Link related specs in this folder if they must land first.
 
+## Open product decisions
+
+**none** — or list the questions this PR must ask the human. Do not ask gates that belong to another PR (`IMPLEMENTATION_ORDER.md`). If this section is **none**, implement without asking.
+
 ## Scope
 
 - [ ] Concrete code/behavior changes for this PR.


### PR DESCRIPTION
## Summary

Harden relaunch agent docs so the next chat can be `Start with R2` (or `Start with PR 2`). Spec drafting, stacking, and which product questions to ask now live in the repo instead of a long handoff prompt. Records that Rootstock testnet already accepted 0.8.36 / cancun.

## Assigned relaunch task spec

- Spec: n/a — not a behavior R-item; docs for the relaunch agent workflow
- R-item (if any): n/a
- Stacked on (branch or “`main`”): `main` (PR 42 merged)

## Scope / out of scope

**In scope**

- `AGENTS.md` starting-a-relaunch-chat + git stacking
- `IMPLEMENTATION_ORDER.md` Ask column per PR; EVM proof marked passed
- `docs/relaunch/README.md` status after R23 merge
- `TASK_TEMPLATE.md` Open product decisions section

**Out of scope (not in this PR)**

- R2 / any Solidity
- Fee / R18 / R19 decisions

## Tests run

Docs only.

## ABI changes

- [x] None

## Deployment / script impact

- [x] None

## Security considerations

No invariant changes.

## Reviewer checklist

- [ ] Matches the assigned spec (or is clearly not a relaunch item)
- [ ] No optional / further-review work unless the spec assigned it
- [ ] PR is small and behavior-scoped; no unrelated refactors
- [ ] Extra files beyond the spec are listed and justified
- [ ] Tests listed above were run locally
- [ ] GitHub Actions CI is green after the latest push
- [ ] Protocol invariants in `AGENTS.md` still hold unless the spec changed one
- [ ] No broadcast, live-chain interaction, or secrets in the diff