### PR TITLE
feat: UTC day-boundary purchase eligibility (R2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,14 @@ Handlers = TokenHandler + TokenLending + a Purchase*:
 - `test/unit/`, `test/mocks/`, `test/ai-generated/` — unit / mocks / extra + fuzz.
 - `script/` — deploy helpers. Do not `--broadcast` or talk to live contracts.
 
+## Match existing code
+
+The spec is the behavior source of truth. It is not a license to invent a new shape when the file already has one.
+
+Before adding a helper, read the neighboring functions in that file and copy their pattern unless the spec is explicitly changing that convention, or you have a concrete reason (say so in the PR).
+
+In `DcaManager`, argument checks are private `_validate*` functions called from the constructor or function body (`_validatePurchasePeriod`, `_validateDeposit`, `_validatePurchaseAmount`). Modifiers are for gates reused across many externals (`validateScheduleIndex`, `onlySwapper`). Do not add a new modifier because the spec said “modifier” if a private function would match those neighbors.
+
 ## Protocol invariants
 
 Unless the assigned spec explicitly changes one:

--- a/docs/relaunch/R2-utc-purchase-period.md
+++ b/docs/relaunch/R2-utc-purchase-period.md
@@ -24,15 +24,13 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
 
   ```solidity
   uint256 currentDayStart = block.timestamp - (block.timestamp % 1 days);
-  uint256 nextPurchaseDayStart =
-      lastPurchaseTimestamp + purchasePeriod
-      - (lastPurchaseTimestamp + purchasePeriod) % 1 days;
-  if (lastPurchaseTimestamp != 0 && currentDayStart < nextPurchaseDayStart) {
-      revert DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(/* time until nextPurchaseDayStart */);
+  uint256 nextDueTimestamp = lastPurchaseTimestamp + purchasePeriod;
+  if (lastPurchaseTimestamp != 0 && currentDayStart < nextDueTimestamp) {
+      revert DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(/* time until nextDueTimestamp */);
   }
   ```
 
-  Keep the existing error. `timeRemaining` is seconds until `nextPurchaseDayStart` (`nextPurchaseDayStart - block.timestamp`).
+  Keep the existing error. `timeRemaining` is seconds until `nextDueTimestamp` (`nextDueTimestamp - block.timestamp`). `last` and `period` are whole UTC days, so `last + period` is already 00:00 UTC of the due day.
 
 - [x] Keep the `6335994` snap. Periods must be whole UTC days (`period % 1 days == 0`) on the protocol min (constructor / `modifyMinPurchasePeriod`) and on user schedules (`_validatePurchasePeriod`). First purchase stamps 00:00 UTC; later purchases add `periodsElapsed * purchasePeriod` from that midnight so weekly stays on the original weekday after a gap:
 

--- a/docs/relaunch/R2-utc-purchase-period.md
+++ b/docs/relaunch/R2-utc-purchase-period.md
@@ -45,7 +45,7 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
 
   Actual execution time is the purchase transaction's `block.timestamp` (indexer / `PurchaseRbtc__RbtcBought` log), not this field.
 
-- [x] Add modifier `validateMinPurchasePeriod`: revert if `minPurchasePeriod < 1 days` or not a multiple of 1 day. Apply on `constructor` and `modifyMinPurchasePeriod`. Errors on `IDcaManager`: `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`, `DcaManager__PurchasePeriodMustBeWholeDays`. User schedules still cannot go below `s_minPurchasePeriod` (`_validatePurchasePeriod`).
+- [x] Add `_validateMinPurchasePeriod`: revert if `minPurchasePeriod < 1 days` or not a multiple of 1 day. Call from `constructor` and `modifyMinPurchasePeriod`. Errors on `IDcaManager`: `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`, `DcaManager__PurchasePeriodMustBeWholeDays`. User schedules still cannot go below `s_minPurchasePeriod` (`_validatePurchasePeriod`).
 
 ## Out of scope
 

--- a/docs/relaunch/R2-utc-purchase-period.md
+++ b/docs/relaunch/R2-utc-purchase-period.md
@@ -34,14 +34,13 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
 
   Keep the existing error. `timeRemaining` is seconds until `nextPurchaseDayStart` (`nextPurchaseDayStart - block.timestamp`).
 
-- [x] Keep the `6335994` snap, aligned to UTC due days. Floor `periodsElapsed` at 1 so an early UTC-day buy still consumes a slot. If that wall-clock snap still leaves today's UTC day due (multi-period gap after a late-in-day `last`), consume one more period so a second buy the same day reverts:
+- [x] Keep the `6335994` snap, aligned to UTC due days. If that wall-clock snap still leaves today's UTC day due (multi-period gap after a late-in-day `last`), consume one more period so a second buy the same day reverts:
 
   ```solidity
   if (lastPurchaseTimestamp == 0) {
       lastPurchaseTimestamp = block.timestamp - (block.timestamp % 1 days);
   } else {
       uint256 periodsElapsed = (block.timestamp - lastPurchaseTimestamp) / purchasePeriod;
-      if (periodsElapsed == 0) periodsElapsed = 1;
       lastPurchaseTimestamp += periodsElapsed * purchasePeriod;
       uint256 nextDueTimestamp = lastPurchaseTimestamp + purchasePeriod;
       uint256 nextPurchaseDayStart = nextDueTimestamp - (nextDueTimestamp % 1 days);
@@ -51,7 +50,7 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
   }
   ```
 
-  First purchase stamps 00:00 UTC of that day. Later purchases add whole periods from that midnight so a weekly schedule keeps its weekday after a gap. Floor / extra-period remain as guards. Actual execution time is the purchase transaction's `block.timestamp` (indexer / `PurchaseRbtc__RbtcBought` log), not this field.
+  First purchase stamps 00:00 UTC of that day. Later purchases add whole periods from that midnight so a weekly schedule keeps its weekday after a gap. Actual execution time is the purchase transaction's `block.timestamp` (indexer / `PurchaseRbtc__RbtcBought` log), not this field.
 
 - [x] Add modifier `validateMinPurchasePeriod`: revert if `minPurchasePeriod < 1 days`. Apply on `constructor` and `modifyMinPurchasePeriod`. New error on `IDcaManager` (e.g. `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`). User schedules still cannot go below `s_minPurchasePeriod` (`_validatePurchasePeriod` unchanged in spirit).
 

--- a/docs/relaunch/R2-utc-purchase-period.md
+++ b/docs/relaunch/R2-utc-purchase-period.md
@@ -8,11 +8,11 @@ Treat a schedule as eligible once the UTC calendar day of `lastPurchaseTimestamp
 
 ## Background
 
-Eligibility today requires a full `purchasePeriod` of wall-clock seconds since `lastPurchaseTimestamp`. A first daily buy at 20:00 UTC blocks the next buy until 20:00 the following day.
+Eligibility used to require a full `purchasePeriod` of wall-clock seconds since `lastPurchaseTimestamp`. A first daily buy at 20:00 UTC blocked the next buy until 20:00 the following day.
 
-Missed-period timestamp snap (`6335994`) already landed: after a gap, `lastPurchaseTimestamp` advances by `periodsElapsed * purchasePeriod`, not `1 * period`. **Keep that snap.** First purchase (`lastPurchaseTimestamp == 0`) still stamps `block.timestamp`.
+Missed-period timestamp snap (`6335994`) already landed: after a gap, `lastPurchaseTimestamp` advances by `periodsElapsed * purchasePeriod`, not `1 * period`. **Keep that snap.** First purchase (`lastPurchaseTimestamp == 0`) stamps 00:00 UTC of that day, not `block.timestamp`.
 
-R2 replaces the remaining strict-seconds check. Daily is the highest frequency BitChill will support; the one-day floor is both required by the UTC-day math (a sub-day period would round to 00:00 today and allow an immediate second buy) and the intended product maximum.
+R2 replaces the remaining strict-seconds check. Daily is the highest frequency BitChill will support; periods must be whole UTC days (`period % 1 days == 0`) and at least one day. That is both required by the UTC-day math (a sub-day period would round to 00:00 today and allow an immediate second buy) and the intended product maximum.
 
 ## Open product decisions
 
@@ -114,6 +114,6 @@ Fork tests: not required.
 
 ## ABI / deploy / cutover impact
 
-- ABI: new error `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`. Existing `DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(uint256 timeRemaining)` kept; `timeRemaining` is now seconds until 00:00 UTC of the due day, not until `last + period` wall-clock. No function or event signature changes.
+- ABI: new errors `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay` and `DcaManager__PurchasePeriodMustBeWholeDays`. Existing `DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(uint256 timeRemaining)` kept; `timeRemaining` is now seconds until 00:00 UTC of the due day, not until `last + period` wall-clock. No function or event signature changes.
 - Scripts: none. Deploy scripts already pass `MIN_PURCHASE_PERIOD = 1 days`.
 - Cutover: swapper may run at a fixed UTC time once the due calendar day has started. `lastPurchaseTimestamp` is the UTC-day grid (first buy's 00:00, then whole periods), not execution time. Indexers should use `PurchaseRbtc__RbtcBought` plus the log's `block.timestamp` for purchase history. Do not include broadcast steps.

--- a/docs/relaunch/R2-utc-purchase-period.md
+++ b/docs/relaunch/R2-utc-purchase-period.md
@@ -38,8 +38,7 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
 
   ```solidity
   if (lastPurchaseTimestamp == 0) {
-      uint256 dayStart = block.timestamp - (block.timestamp % 1 days);
-      lastPurchaseTimestamp = dayStart == 0 ? 1 : dayStart; // 0 stays "never purchased"
+      lastPurchaseTimestamp = block.timestamp - (block.timestamp % 1 days);
   } else {
       uint256 periodsElapsed = (block.timestamp - lastPurchaseTimestamp) / purchasePeriod;
       if (periodsElapsed == 0) periodsElapsed = 1;

--- a/docs/relaunch/R2-utc-purchase-period.md
+++ b/docs/relaunch/R2-utc-purchase-period.md
@@ -1,0 +1,119 @@
+# R2 — UTC purchase-period day boundary
+
+Status: **in progress** · Assigned: yes · Optional/further-review: no
+
+## Objective
+
+Treat a schedule as eligible once the UTC calendar day of `lastPurchaseTimestamp + purchasePeriod` has started, and reject a protocol minimum period below one day, so the swapper can run at a fixed UTC time of day.
+
+## Background
+
+Eligibility today requires a full `purchasePeriod` of wall-clock seconds since `lastPurchaseTimestamp`. A first daily buy at 20:00 UTC blocks the next buy until 20:00 the following day.
+
+Missed-period timestamp snap (`6335994`) already landed: after a gap, `lastPurchaseTimestamp` advances by `periodsElapsed * purchasePeriod`, not `1 * period`. **Keep that snap.** First purchase (`lastPurchaseTimestamp == 0`) still stamps `block.timestamp`.
+
+R2 replaces the remaining strict-seconds check. Daily is the highest frequency BitChill will support; the one-day floor is both required by the UTC-day math (a sub-day period would round to 00:00 today and allow an immediate second buy) and the intended product maximum.
+
+## Open product decisions
+
+**none**
+
+## Scope
+
+- [x] In `DcaManager._rBtcPurchaseChecksEffects`, replace the strict `block.timestamp - last < purchasePeriod` check with UTC day-boundary eligibility:
+
+  ```solidity
+  uint256 currentDayStart = block.timestamp - (block.timestamp % 1 days);
+  uint256 nextPurchaseDayStart =
+      lastPurchaseTimestamp + purchasePeriod
+      - (lastPurchaseTimestamp + purchasePeriod) % 1 days;
+  if (lastPurchaseTimestamp != 0 && currentDayStart < nextPurchaseDayStart) {
+      revert DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(/* time until nextPurchaseDayStart */);
+  }
+  ```
+
+  Keep the existing error. `timeRemaining` is seconds until `nextPurchaseDayStart` (`nextPurchaseDayStart - block.timestamp`).
+
+- [x] Keep the `6335994` snap. Floor `periodsElapsed` at 1 so an early UTC-day buy (allowed before `last + period` wall-clock) still consumes a slot and a same-day second buy reverts:
+
+  ```solidity
+  if (lastPurchaseTimestamp == 0) {
+      lastPurchaseTimestamp = block.timestamp;
+  } else {
+      uint256 periodsElapsed = (block.timestamp - lastPurchaseTimestamp) / purchasePeriod;
+      if (periodsElapsed == 0) periodsElapsed = 1;
+      lastPurchaseTimestamp += periodsElapsed * purchasePeriod;
+  }
+  ```
+
+  After an early UTC-day buy, `lastPurchaseTimestamp` may be greater than `block.timestamp`. That is intended.
+
+- [x] Add modifier `validateMinPurchasePeriod`: revert if `minPurchasePeriod < 1 days`. Apply on `constructor` and `modifyMinPurchasePeriod`. New error on `IDcaManager` (e.g. `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`). User schedules still cannot go below `s_minPurchasePeriod` (`_validatePurchasePeriod` unchanged in spirit).
+
+## Out of scope
+
+- [ ] Fee model, R18 packing, R19 pause, R12/R13/optionals (PR 2 / later PRs).
+- [ ] R7 / R11 / R14 (`createDcaSchedule` max check, one-purchase funding, accumulated-rBTC getters).
+- [ ] Event reshaping, storage packing, pause.
+- [ ] Handler / accounting / SIP-0094 work (R1, R20).
+- [ ] `forge fmt` of existing files.
+- [ ] Deploy broadcasts or live addresses.
+- [ ] `dca-out-contracts`.
+
+## Files likely touched
+
+- `src/DcaManager.sol`
+- `src/interfaces/IDcaManager.sol`
+- `test/unit/RbtcPurchaseTest.t.sol`
+- `test/unit/ModifiersTest.t.sol`
+- `docs/relaunch/README.md` (assignment status)
+
+Implementer may follow failing tests into `test/ai-generated/fuzz/Handler.t.sol` (owner `modifyMinPurchasePeriod` currently bounds down to `1 hours`) and other constructor/`modifyMinPurchasePeriod` call sites. Extra files belong in the PR write-up.
+
+## Required tests
+
+Commands (targeted first, then done-gate):
+
+```bash
+SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus forge test --match-path test/unit/RbtcPurchaseTest.t.sol --match-path test/unit/ModifiersTest.t.sol
+# If fuzz handler bound must change:
+LENDING_PROTOCOL=tropykus SWAP_TYPE=mocSwaps forge test --match-contract InvariantTest
+make check
+```
+
+(`forge test` does not take two `--match-path` flags; use `--match-contract RbtcPurchaseTest` / `ModifiersTest`, or one path per invocation.)
+
+Behaviors to assert:
+
+- First buy late in the UTC day → next buy allowed at 00:00 UTC of the due day, even if `last + period` is still hours away.
+- Still reverts one second before 00:00 UTC of the due day.
+- Same-block / same-day second buy still reverts (`testCannotBuyIfPeriodNotElapsed` keeps passing; update the error's `timeRemaining` to seconds until the due UTC day start).
+- Weekly: allowed any time on the due UTC day, not only after the exact second.
+- Owner cannot set `minPurchasePeriod` below 1 day (constructor + `modifyMinPurchasePeriod`). `1 days` remains valid.
+- Existing `testLastPurchaseTimestampConsistencyWhenScheduleResumed`: gap of N days still advances `N * period`, not `1 * period`.
+- Buy allowed by UTC-day but still before `last + period` wall-clock: timestamp advances by **one** period (`periodsElapsed` floor); same-day second buy reverts.
+
+Fork tests: not required.
+
+## Success criteria
+
+- [x] Daily and weekly schedules can be executed at a consistent UTC time of day without waiting out a delayed previous run.
+- [x] Protocol min cannot be set below 1 day (constructor and owner setter).
+- [x] Missed-period snap (`6335994`) still holds; `periodsElapsed` floor of 1 prevents same-day double-buy after an early UTC-day purchase.
+- [x] `testCannotBuyIfPeriodNotElapsed` still reverts.
+- [x] Targeted tests above pass; `make check` passes.
+- [x] Protocol invariants in `AGENTS.md` unchanged.
+
+## Reviewer checklist
+
+- [ ] Matches **Scope**; nothing from **Out of scope**.
+- [ ] Protocol invariants in `AGENTS.md` still hold (this spec does not change them).
+- [ ] Tests in the PR match **Required tests**.
+- [ ] Files beyond this list are limited to direct dependencies / failing-test fallout and are named in the PR.
+- [ ] No unrelated refactors; history is reviewable.
+
+## ABI / deploy / cutover impact
+
+- ABI: new error `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`. Existing `DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(uint256 timeRemaining)` kept; `timeRemaining` is now seconds until 00:00 UTC of the due day, not until `last + period` wall-clock. No function or event signature changes.
+- Scripts: none. Deploy scripts already pass `MIN_PURCHASE_PERIOD = 1 days`.
+- Cutover: swapper may run at a fixed UTC time once the due calendar day has started. Frontend/ops: eligibility is UTC-day, not exact second. Do not include broadcast steps.

--- a/docs/relaunch/R2-utc-purchase-period.md
+++ b/docs/relaunch/R2-utc-purchase-period.md
@@ -38,7 +38,8 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
 
   ```solidity
   if (lastPurchaseTimestamp == 0) {
-      lastPurchaseTimestamp = block.timestamp;
+      uint256 dayStart = block.timestamp - (block.timestamp % 1 days);
+      lastPurchaseTimestamp = dayStart == 0 ? 1 : dayStart; // 0 stays "never purchased"
   } else {
       uint256 periodsElapsed = (block.timestamp - lastPurchaseTimestamp) / purchasePeriod;
       if (periodsElapsed == 0) periodsElapsed = 1;
@@ -51,7 +52,7 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
   }
   ```
 
-  After an early UTC-day buy, `lastPurchaseTimestamp` may be greater than `block.timestamp`. That is intended.
+  First purchase stamps 00:00 UTC of that day. Later purchases add whole periods from that midnight so a weekly schedule keeps its weekday after a gap. Floor / extra-period remain as guards. Actual execution time is the purchase transaction's `block.timestamp` (indexer / `PurchaseRbtc__RbtcBought` log), not this field.
 
 - [x] Add modifier `validateMinPurchasePeriod`: revert if `minPurchasePeriod < 1 days`. Apply on `constructor` and `modifyMinPurchasePeriod`. New error on `IDcaManager` (e.g. `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`). User schedules still cannot go below `s_minPurchasePeriod` (`_validatePurchasePeriod` unchanged in spirit).
 
@@ -90,7 +91,7 @@ make check
 
 Behaviors to assert:
 
-- First buy late in the UTC day → next buy allowed at 00:00 UTC of the due day, even if `last + period` is still hours away.
+- First buy late in the UTC day → `lastPurchaseTimestamp` is 00:00 UTC of that day (not `block.timestamp`); next buy allowed at 00:00 UTC of the due day.
 - Still reverts one second before 00:00 UTC of the due day.
 - Same-block / same-day second buy still reverts (`testCannotBuyIfPeriodNotElapsed` keeps passing; update the error's `timeRemaining` to seconds until the due UTC day start).
 - Weekly: allowed any time on the due UTC day, not only after the exact second.
@@ -122,4 +123,4 @@ Fork tests: not required.
 
 - ABI: new error `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`. Existing `DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(uint256 timeRemaining)` kept; `timeRemaining` is now seconds until 00:00 UTC of the due day, not until `last + period` wall-clock. No function or event signature changes.
 - Scripts: none. Deploy scripts already pass `MIN_PURCHASE_PERIOD = 1 days`.
-- Cutover: swapper may run at a fixed UTC time once the due calendar day has started. Frontend/ops: eligibility is UTC-day, not exact second. Do not include broadcast steps.
+- Cutover: swapper may run at a fixed UTC time once the due calendar day has started. `lastPurchaseTimestamp` is the UTC-day grid (first buy's 00:00, then whole periods), not execution time. Indexers should use `PurchaseRbtc__RbtcBought` plus the log's `block.timestamp` for purchase history. Do not include broadcast steps.

--- a/docs/relaunch/R2-utc-purchase-period.md
+++ b/docs/relaunch/R2-utc-purchase-period.md
@@ -34,7 +34,7 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
 
   Keep the existing error. `timeRemaining` is seconds until `nextPurchaseDayStart` (`nextPurchaseDayStart - block.timestamp`).
 
-- [x] Keep the `6335994` snap. Floor `periodsElapsed` at 1 so an early UTC-day buy (allowed before `last + period` wall-clock) still consumes a slot and a same-day second buy reverts:
+- [x] Keep the `6335994` snap, aligned to UTC due days. Floor `periodsElapsed` at 1 so an early UTC-day buy still consumes a slot. If that wall-clock snap still leaves today's UTC day due (multi-period gap after a late-in-day `last`), consume one more period so a second buy the same day reverts:
 
   ```solidity
   if (lastPurchaseTimestamp == 0) {
@@ -43,6 +43,11 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
       uint256 periodsElapsed = (block.timestamp - lastPurchaseTimestamp) / purchasePeriod;
       if (periodsElapsed == 0) periodsElapsed = 1;
       lastPurchaseTimestamp += periodsElapsed * purchasePeriod;
+      uint256 nextDueTimestamp = lastPurchaseTimestamp + purchasePeriod;
+      uint256 nextPurchaseDayStart = nextDueTimestamp - (nextDueTimestamp % 1 days);
+      if (currentDayStart >= nextPurchaseDayStart) {
+          lastPurchaseTimestamp += purchasePeriod;
+      }
   }
   ```
 
@@ -90,8 +95,9 @@ Behaviors to assert:
 - Same-block / same-day second buy still reverts (`testCannotBuyIfPeriodNotElapsed` keeps passing; update the error's `timeRemaining` to seconds until the due UTC day start).
 - Weekly: allowed any time on the due UTC day, not only after the exact second.
 - Owner cannot set `minPurchasePeriod` below 1 day (constructor + `modifyMinPurchasePeriod`). `1 days` remains valid.
-- Existing `testLastPurchaseTimestampConsistencyWhenScheduleResumed`: gap of N days still advances `N * period`, not `1 * period`.
+- Existing `testLastPurchaseTimestampConsistencyWhenScheduleResumed`: gap snap still skips missed slots (not `1 * period`); expected `last` is the latest period whose UTC due day has started.
 - Buy allowed by UTC-day but still before `last + period` wall-clock: timestamp advances by **one** period (`periodsElapsed` floor); same-day second buy reverts.
+- Gap resume on the UTC start of the third due day (first buy 20:00, warp to day 3 00:00): `last` advances to the **third** period slot; same-day second buy reverts.
 
 Fork tests: not required.
 
@@ -99,7 +105,7 @@ Fork tests: not required.
 
 - [x] Daily and weekly schedules can be executed at a consistent UTC time of day without waiting out a delayed previous run.
 - [x] Protocol min cannot be set below 1 day (constructor and owner setter).
-- [x] Missed-period snap (`6335994`) still holds; `periodsElapsed` floor of 1 prevents same-day double-buy after an early UTC-day purchase.
+- [x] Missed-period snap (`6335994`) still holds; `periodsElapsed` floor of 1 plus a UTC-due-day extra period prevent same-day double-buy after an early UTC-day purchase **and** after a multi-period gap.
 - [x] `testCannotBuyIfPeriodNotElapsed` still reverts.
 - [x] Targeted tests above pass; `make check` passes.
 - [x] Protocol invariants in `AGENTS.md` unchanged.

--- a/docs/relaunch/R2-utc-purchase-period.md
+++ b/docs/relaunch/R2-utc-purchase-period.md
@@ -34,7 +34,7 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
 
   Keep the existing error. `timeRemaining` is seconds until `nextPurchaseDayStart` (`nextPurchaseDayStart - block.timestamp`).
 
-- [x] Keep the `6335994` snap, aligned to UTC due days. If that wall-clock snap still leaves today's UTC day due (multi-period gap after a late-in-day `last`), consume one more period so a second buy the same day reverts:
+- [x] Keep the `6335994` snap. Periods must be whole UTC days (`period % 1 days == 0`) on the protocol min (constructor / `modifyMinPurchasePeriod`) and on user schedules (`_validatePurchasePeriod`). First purchase stamps 00:00 UTC; later purchases add `periodsElapsed * purchasePeriod` from that midnight so weekly stays on the original weekday after a gap:
 
   ```solidity
   if (lastPurchaseTimestamp == 0) {
@@ -42,17 +42,12 @@ R2 replaces the remaining strict-seconds check. Daily is the highest frequency B
   } else {
       uint256 periodsElapsed = (block.timestamp - lastPurchaseTimestamp) / purchasePeriod;
       lastPurchaseTimestamp += periodsElapsed * purchasePeriod;
-      uint256 nextDueTimestamp = lastPurchaseTimestamp + purchasePeriod;
-      uint256 nextPurchaseDayStart = nextDueTimestamp - (nextDueTimestamp % 1 days);
-      if (currentDayStart >= nextPurchaseDayStart) {
-          lastPurchaseTimestamp += purchasePeriod;
-      }
   }
   ```
 
-  First purchase stamps 00:00 UTC of that day. Later purchases add whole periods from that midnight so a weekly schedule keeps its weekday after a gap. Actual execution time is the purchase transaction's `block.timestamp` (indexer / `PurchaseRbtc__RbtcBought` log), not this field.
+  Actual execution time is the purchase transaction's `block.timestamp` (indexer / `PurchaseRbtc__RbtcBought` log), not this field.
 
-- [x] Add modifier `validateMinPurchasePeriod`: revert if `minPurchasePeriod < 1 days`. Apply on `constructor` and `modifyMinPurchasePeriod`. New error on `IDcaManager` (e.g. `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`). User schedules still cannot go below `s_minPurchasePeriod` (`_validatePurchasePeriod` unchanged in spirit).
+- [x] Add modifier `validateMinPurchasePeriod`: revert if `minPurchasePeriod < 1 days` or not a multiple of 1 day. Apply on `constructor` and `modifyMinPurchasePeriod`. Errors on `IDcaManager`: `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay`, `DcaManager__PurchasePeriodMustBeWholeDays`. User schedules still cannot go below `s_minPurchasePeriod` (`_validatePurchasePeriod`).
 
 ## Out of scope
 
@@ -93,9 +88,9 @@ Behaviors to assert:
 - Still reverts one second before 00:00 UTC of the due day.
 - Same-block / same-day second buy still reverts (`testCannotBuyIfPeriodNotElapsed` keeps passing; update the error's `timeRemaining` to seconds until the due UTC day start).
 - Weekly: allowed any time on the due UTC day, not only after the exact second.
-- Owner cannot set `minPurchasePeriod` below 1 day (constructor + `modifyMinPurchasePeriod`). `1 days` remains valid.
+- Owner cannot set `minPurchasePeriod` below 1 day or to a non-whole number of days (constructor + `modifyMinPurchasePeriod`). `1 days` remains valid. User `purchasePeriod` must be a multiple of 1 day.
 - Existing `testLastPurchaseTimestampConsistencyWhenScheduleResumed`: gap snap still skips missed slots (not `1 * period`); expected `last` is the latest period whose UTC due day has started.
-- Buy allowed by UTC-day but still before `last + period` wall-clock: timestamp advances by **one** period (`periodsElapsed` floor); same-day second buy reverts.
+- Buy allowed by UTC-day: timestamp advances by whole periods from the midnight grid; same-day second buy reverts.
 - Gap resume on the UTC start of the third due day (first buy 20:00, warp to day 3 00:00): `last` advances to the **third** period slot; same-day second buy reverts.
 
 Fork tests: not required.
@@ -103,8 +98,8 @@ Fork tests: not required.
 ## Success criteria
 
 - [x] Daily and weekly schedules can be executed at a consistent UTC time of day without waiting out a delayed previous run.
-- [x] Protocol min cannot be set below 1 day (constructor and owner setter).
-- [x] Missed-period snap (`6335994`) still holds; `periodsElapsed` floor of 1 plus a UTC-due-day extra period prevent same-day double-buy after an early UTC-day purchase **and** after a multi-period gap.
+- [x] Protocol min cannot be set below 1 day and must be a whole number of days (constructor and owner setter). User periods must be whole days.
+- [x] Missed-period snap (`6335994`) still holds; midnight first stamp plus whole-day periods prevent same-day double-buy after an early UTC-day purchase and after a multi-period gap.
 - [x] `testCannotBuyIfPeriodNotElapsed` still reverts.
 - [x] Targeted tests above pass; `make check` passes.
 - [x] Protocol invariants in `AGENTS.md` unchanged.

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -21,5 +21,5 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 ## Status
 
 - Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub [#42](https://github.com/BitChillRSK/dca-contracts/pull/42)). Rootstock testnet accepted solc 0.8.36 / `cancun`.
-- Assigned: [R2-utc-purchase-period.md](./R2-utc-purchase-period.md) (PR 3). No product gates. Does not wait on PR 2.
+- Assigned: [R2-utc-purchase-period.md](./R2-utc-purchase-period.md) (PR 3, GitHub [#44](https://github.com/BitChillRSK/dca-contracts/pull/44)). No product gates. Does not wait on PR 2.
 - Next unassigned: `Start with R7` (PR 4, DcaManager small fixes: R7 / R11 / R14). No product gates. PR 2 (decision record) stays available when the human wants to record fee / R18 / R19.

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -21,5 +21,5 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 ## Status
 
 - Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub [#42](https://github.com/BitChillRSK/dca-contracts/pull/42)). Rootstock testnet accepted solc 0.8.36 / `cancun`.
-- Assigned: none.
-- Next unassigned: `Start with R2` (PR 3, UTC purchase-period). No product gates. Does not wait on PR 2.
+- Assigned: [R2-utc-purchase-period.md](./R2-utc-purchase-period.md) (PR 3). No product gates. Does not wait on PR 2.
+- Next unassigned: `Start with R7` (PR 4, DcaManager small fixes: R7 / R11 / R14). No product gates. PR 2 (decision record) stays available when the human wants to record fee / R18 / R19.

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,6 +11,9 @@ remappings = [
 
 solc_version = "0.8.36"
 evm_version = "cancun"
+# Local Anvil defaults to timestamp 1. 00:00 UTC of that day is 0, which DcaManager
+# treats as "never purchased". Production Rootstock cannot hit that; tests should not either.
+block_timestamp = 86400
 
 [fuzz]
 runs = 1000

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -511,6 +511,10 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
         _requireWholeDays(purchasePeriod);
     }
 
+    /**
+     * @notice require that the period is a whole day
+     * @param period the period to validate
+     */
     function _requireWholeDays(uint256 period) private pure {
         if (period % 1 days != 0) revert DcaManager__PurchasePeriodMustBeWholeDays();
     }

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -48,16 +48,6 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice protocol minimum purchase period cannot be below one day
-     * @param minPurchasePeriod the minimum purchase period to validate
-     */
-    modifier validateMinPurchasePeriod(uint256 minPurchasePeriod) {
-        if (minPurchasePeriod < 1 days) revert DcaManager__MinPurchasePeriodMustBeAtLeastOneDay();
-        _requireWholeDays(minPurchasePeriod);
-        _;
-    }
-
-    /**
      * @notice only allow swapper role
      */
     modifier onlySwapper() {
@@ -79,8 +69,8 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
      */
     constructor(address operationsAdminAddress, uint256 minPurchasePeriod, uint256 maxSchedulesPerToken, uint256 defaultMinPurchaseAmount)
         Ownable()
-        validateMinPurchasePeriod(minPurchasePeriod)
     {
+        _validateMinPurchasePeriod(minPurchasePeriod);
         s_operationsAdmin = OperationsAdmin(operationsAdminAddress);
         s_minPurchasePeriod = minPurchasePeriod;
         s_maxSchedulesPerToken = maxSchedulesPerToken;
@@ -429,8 +419,8 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
         external
         override
         onlyOwner
-        validateMinPurchasePeriod(minPurchasePeriod)
     {
+        _validateMinPurchasePeriod(minPurchasePeriod);
         s_minPurchasePeriod = minPurchasePeriod;
         emit DcaManager__MinPurchasePeriodModified(minPurchasePeriod);
     }
@@ -501,6 +491,15 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
         if (purchaseAmount > (tokenBalance) / 2) {
             revert DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance();
         }
+    }
+
+    /**
+     * @notice validate the protocol minimum purchase period
+     * @param minPurchasePeriod the minimum purchase period to validate
+     */
+    function _validateMinPurchasePeriod(uint256 minPurchasePeriod) private pure {
+        if (minPurchasePeriod < 1 days) revert DcaManager__MinPurchasePeriodMustBeAtLeastOneDay();
+        _requireWholeDays(minPurchasePeriod);
     }
 
     /**

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -48,7 +48,7 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice protocol minimum purchase period cannot be below one UTC day
+     * @notice protocol minimum purchase period cannot be below one day
      * @param minPurchasePeriod the minimum purchase period to validate
      */
     modifier validateMinPurchasePeriod(uint256 minPurchasePeriod) {
@@ -554,14 +554,14 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
 
         _validateScheduleId(scheduleId, dcaSchedule.scheduleId);
 
-        // @notice: After the first purchase, the schedule is eligible once the UTC day of last + period has started
+        // After the first purchase, eligible once the UTC day of last + period has started.
+        // last and period are whole days, so last + period is already that day's 00:00 UTC.
         uint256 currentDayStart;
         if (dcaSchedule.lastPurchaseTimestamp != 0) {
             currentDayStart = block.timestamp - (block.timestamp % 1 days);
             uint256 nextDueTimestamp = dcaSchedule.lastPurchaseTimestamp + dcaSchedule.purchasePeriod;
-            uint256 nextPurchaseDayStart = nextDueTimestamp - (nextDueTimestamp % 1 days);
-            if (currentDayStart < nextPurchaseDayStart) {
-                revert DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(nextPurchaseDayStart - block.timestamp);
+            if (currentDayStart < nextDueTimestamp) {
+                revert DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(nextDueTimestamp - block.timestamp);
             }
         }
 

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -571,8 +571,7 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
         // original weekday after a gap. Floor periodsElapsed at 1, then consume one more
         // period if that snap still leaves today's UTC day due.
         if (dcaSchedule.lastPurchaseTimestamp == 0) {
-            uint256 dayStart = block.timestamp - (block.timestamp % 1 days);
-            dcaSchedule.lastPurchaseTimestamp = dayStart == 0 ? 1 : dayStart;
+            dcaSchedule.lastPurchaseTimestamp = block.timestamp - (block.timestamp % 1 days);
         } else {
             uint256 periodsElapsed = (block.timestamp - dcaSchedule.lastPurchaseTimestamp) / dcaSchedule.purchasePeriod;
             if (periodsElapsed == 0) periodsElapsed = 1;

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -549,8 +549,9 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
         _validateScheduleId(scheduleId, dcaSchedule.scheduleId);
 
         // @notice: After the first purchase, the schedule is eligible once the UTC day of last + period has started
+        uint256 currentDayStart;
         if (dcaSchedule.lastPurchaseTimestamp != 0) {
-            uint256 currentDayStart = block.timestamp - (block.timestamp % 1 days);
+            currentDayStart = block.timestamp - (block.timestamp % 1 days);
             uint256 nextDueTimestamp = dcaSchedule.lastPurchaseTimestamp + dcaSchedule.purchasePeriod;
             uint256 nextPurchaseDayStart = nextDueTimestamp - (nextDueTimestamp % 1 days);
             if (currentDayStart < nextPurchaseDayStart) {
@@ -568,7 +569,9 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
         // @notice: this way purchases are possible with the wanted periodicity even if
         // - a previous purchase was delayed
         // - the schedule run out of stablecoin and was resumed later with a new deposit
-        // Floor periodsElapsed at 1 so an early UTC-day buy still consumes a slot
+        // Floor periodsElapsed at 1 so an early UTC-day buy still consumes a slot.
+        // If the wall-clock snap still leaves today's UTC day due (gap after a late-in-day last),
+        // consume one more period so a second buy the same day cannot pass.
         if (dcaSchedule.lastPurchaseTimestamp == 0) {
             dcaSchedule.lastPurchaseTimestamp = block.timestamp;
         } else {
@@ -576,6 +579,13 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
             if (periodsElapsed == 0) periodsElapsed = 1;
             unchecked {
                 dcaSchedule.lastPurchaseTimestamp += periodsElapsed * dcaSchedule.purchasePeriod;
+            }
+            uint256 nextDueTimestamp = dcaSchedule.lastPurchaseTimestamp + dcaSchedule.purchasePeriod;
+            uint256 nextPurchaseDayStart = nextDueTimestamp - (nextDueTimestamp % 1 days);
+            if (currentDayStart >= nextPurchaseDayStart) {
+                unchecked {
+                    dcaSchedule.lastPurchaseTimestamp += dcaSchedule.purchasePeriod;
+                }
             }
         }
         dcaScheduleStorage.lastPurchaseTimestamp = dcaSchedule.lastPurchaseTimestamp;

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -53,6 +53,7 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
      */
     modifier validateMinPurchasePeriod(uint256 minPurchasePeriod) {
         if (minPurchasePeriod < 1 days) revert DcaManager__MinPurchasePeriodMustBeAtLeastOneDay();
+        _requireWholeDays(minPurchasePeriod);
         _;
     }
 
@@ -508,6 +509,11 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
      */
     function _validatePurchasePeriod(uint256 purchasePeriod) private view {
         if (purchasePeriod < s_minPurchasePeriod) revert DcaManager__PurchasePeriodMustBeGreaterThanMinimum();
+        _requireWholeDays(purchasePeriod);
+    }
+
+    function _requireWholeDays(uint256 period) private pure {
+        if (period % 1 days != 0) revert DcaManager__PurchasePeriodMustBeWholeDays();
     }
 
     /**
@@ -568,21 +574,13 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
 
         // First purchase stamps 00:00 UTC of that day (0 stays "never purchased").
         // Later purchases add whole periods from that midnight so weekly stays on the
-        // original weekday after a gap. Consume one more period if that snap still
-        // leaves today's UTC day due.
+        // original weekday after a gap.
         if (dcaSchedule.lastPurchaseTimestamp == 0) {
             dcaSchedule.lastPurchaseTimestamp = block.timestamp - (block.timestamp % 1 days);
         } else {
             uint256 periodsElapsed = (block.timestamp - dcaSchedule.lastPurchaseTimestamp) / dcaSchedule.purchasePeriod;
             unchecked {
                 dcaSchedule.lastPurchaseTimestamp += periodsElapsed * dcaSchedule.purchasePeriod;
-            }
-            uint256 nextDueTimestamp = dcaSchedule.lastPurchaseTimestamp + dcaSchedule.purchasePeriod;
-            uint256 nextPurchaseDayStart = nextDueTimestamp - (nextDueTimestamp % 1 days);
-            if (currentDayStart >= nextPurchaseDayStart) {
-                unchecked {
-                    dcaSchedule.lastPurchaseTimestamp += dcaSchedule.purchasePeriod;
-                }
             }
         }
         dcaScheduleStorage.lastPurchaseTimestamp = dcaSchedule.lastPurchaseTimestamp;

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -48,6 +48,15 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
     }
 
     /**
+     * @notice protocol minimum purchase period cannot be below one UTC day
+     * @param minPurchasePeriod the minimum purchase period to validate
+     */
+    modifier validateMinPurchasePeriod(uint256 minPurchasePeriod) {
+        if (minPurchasePeriod < 1 days) revert DcaManager__MinPurchasePeriodMustBeAtLeastOneDay();
+        _;
+    }
+
+    /**
      * @notice only allow swapper role
      */
     modifier onlySwapper() {
@@ -67,7 +76,10 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
      * @param maxSchedulesPerToken the maximum number of schedules allowed per token
      * @param defaultMinPurchaseAmount the default minimum purchase amount for all tokens
      */
-    constructor(address operationsAdminAddress, uint256 minPurchasePeriod, uint256 maxSchedulesPerToken, uint256 defaultMinPurchaseAmount) Ownable() {
+    constructor(address operationsAdminAddress, uint256 minPurchasePeriod, uint256 maxSchedulesPerToken, uint256 defaultMinPurchaseAmount)
+        Ownable()
+        validateMinPurchasePeriod(minPurchasePeriod)
+    {
         s_operationsAdmin = OperationsAdmin(operationsAdminAddress);
         s_minPurchasePeriod = minPurchasePeriod;
         s_maxSchedulesPerToken = maxSchedulesPerToken;
@@ -412,7 +424,12 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
      * @notice modify the minimum period between purchases
      * @param minPurchasePeriod: the new period
      */
-    function modifyMinPurchasePeriod(uint256 minPurchasePeriod) external override onlyOwner {
+    function modifyMinPurchasePeriod(uint256 minPurchasePeriod)
+        external
+        override
+        onlyOwner
+        validateMinPurchasePeriod(minPurchasePeriod)
+    {
         s_minPurchasePeriod = minPurchasePeriod;
         emit DcaManager__MinPurchasePeriodModified(minPurchasePeriod);
     }
@@ -531,11 +548,14 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
 
         _validateScheduleId(scheduleId, dcaSchedule.scheduleId);
 
-        // @notice: If this is not the first purchase for this schedule, check that period has elapsed before making a new purchase
-        if (dcaSchedule.lastPurchaseTimestamp > 0 && block.timestamp - dcaSchedule.lastPurchaseTimestamp < dcaSchedule.purchasePeriod) {
-            revert DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(
-                dcaSchedule.lastPurchaseTimestamp + dcaSchedule.purchasePeriod - block.timestamp
-            );
+        // @notice: After the first purchase, the schedule is eligible once the UTC day of last + period has started
+        if (dcaSchedule.lastPurchaseTimestamp != 0) {
+            uint256 currentDayStart = block.timestamp - (block.timestamp % 1 days);
+            uint256 nextDueTimestamp = dcaSchedule.lastPurchaseTimestamp + dcaSchedule.purchasePeriod;
+            uint256 nextPurchaseDayStart = nextDueTimestamp - (nextDueTimestamp % 1 days);
+            if (currentDayStart < nextPurchaseDayStart) {
+                revert DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(nextPurchaseDayStart - block.timestamp);
+            }
         }
 
         if (dcaSchedule.purchaseAmount > dcaSchedule.tokenBalance) {
@@ -545,14 +565,18 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
         dcaScheduleStorage.tokenBalance = dcaSchedule.tokenBalance;
         emit DcaManager__TokenBalanceUpdated(token, scheduleId, dcaSchedule.tokenBalance);
 
-        // @notice: this way purchases are possible with the wanted periodicity even if 
+        // @notice: this way purchases are possible with the wanted periodicity even if
         // - a previous purchase was delayed
         // - the schedule run out of stablecoin and was resumed later with a new deposit
-        uint256 periodsElapsed = (block.timestamp - dcaSchedule.lastPurchaseTimestamp) / dcaSchedule.purchasePeriod;
-        unchecked {
-            dcaSchedule.lastPurchaseTimestamp = dcaSchedule.lastPurchaseTimestamp == 0
-                ? block.timestamp
-                : dcaSchedule.lastPurchaseTimestamp + periodsElapsed * dcaSchedule.purchasePeriod;
+        // Floor periodsElapsed at 1 so an early UTC-day buy still consumes a slot
+        if (dcaSchedule.lastPurchaseTimestamp == 0) {
+            dcaSchedule.lastPurchaseTimestamp = block.timestamp;
+        } else {
+            uint256 periodsElapsed = (block.timestamp - dcaSchedule.lastPurchaseTimestamp) / dcaSchedule.purchasePeriod;
+            if (periodsElapsed == 0) periodsElapsed = 1;
+            unchecked {
+                dcaSchedule.lastPurchaseTimestamp += periodsElapsed * dcaSchedule.purchasePeriod;
+            }
         }
         dcaScheduleStorage.lastPurchaseTimestamp = dcaSchedule.lastPurchaseTimestamp;
         emit DcaManager__LastPurchaseTimestampUpdated(token, scheduleId, dcaSchedule.lastPurchaseTimestamp);

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -566,14 +566,13 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
         dcaScheduleStorage.tokenBalance = dcaSchedule.tokenBalance;
         emit DcaManager__TokenBalanceUpdated(token, scheduleId, dcaSchedule.tokenBalance);
 
-        // @notice: this way purchases are possible with the wanted periodicity even if
-        // - a previous purchase was delayed
-        // - the schedule run out of stablecoin and was resumed later with a new deposit
-        // Floor periodsElapsed at 1 so an early UTC-day buy still consumes a slot.
-        // If the wall-clock snap still leaves today's UTC day due (gap after a late-in-day last),
-        // consume one more period so a second buy the same day cannot pass.
+        // First purchase stamps 00:00 UTC of that day (0 stays "never purchased").
+        // Later purchases add whole periods from that midnight so weekly stays on the
+        // original weekday after a gap. Floor periodsElapsed at 1, then consume one more
+        // period if that snap still leaves today's UTC day due.
         if (dcaSchedule.lastPurchaseTimestamp == 0) {
-            dcaSchedule.lastPurchaseTimestamp = block.timestamp;
+            uint256 dayStart = block.timestamp - (block.timestamp % 1 days);
+            dcaSchedule.lastPurchaseTimestamp = dayStart == 0 ? 1 : dayStart;
         } else {
             uint256 periodsElapsed = (block.timestamp - dcaSchedule.lastPurchaseTimestamp) / dcaSchedule.purchasePeriod;
             if (periodsElapsed == 0) periodsElapsed = 1;

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -568,13 +568,12 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
 
         // First purchase stamps 00:00 UTC of that day (0 stays "never purchased").
         // Later purchases add whole periods from that midnight so weekly stays on the
-        // original weekday after a gap. Floor periodsElapsed at 1, then consume one more
-        // period if that snap still leaves today's UTC day due.
+        // original weekday after a gap. Consume one more period if that snap still
+        // leaves today's UTC day due.
         if (dcaSchedule.lastPurchaseTimestamp == 0) {
             dcaSchedule.lastPurchaseTimestamp = block.timestamp - (block.timestamp % 1 days);
         } else {
             uint256 periodsElapsed = (block.timestamp - dcaSchedule.lastPurchaseTimestamp) / dcaSchedule.purchasePeriod;
-            if (periodsElapsed == 0) periodsElapsed = 1;
             unchecked {
                 dcaSchedule.lastPurchaseTimestamp += periodsElapsed * dcaSchedule.purchasePeriod;
             }

--- a/src/interfaces/IDcaManager.sol
+++ b/src/interfaces/IDcaManager.sol
@@ -63,6 +63,7 @@ interface IDcaManager {
     error DcaManager__WithdrawalAmountExceedsBalance(address token, uint256 amount, uint256 balance);
     error DcaManager__PurchaseAmountMustBeGreaterThanMinimum(address token, uint256 minPurchaseAmount);
     error DcaManager__PurchasePeriodMustBeGreaterThanMinimum();
+    error DcaManager__MinPurchasePeriodMustBeAtLeastOneDay();
     error DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance();
     error DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(uint256 timeRemaining);
     error DcaManager__InexistentScheduleIndex();

--- a/src/interfaces/IDcaManager.sol
+++ b/src/interfaces/IDcaManager.sol
@@ -64,6 +64,7 @@ interface IDcaManager {
     error DcaManager__PurchaseAmountMustBeGreaterThanMinimum(address token, uint256 minPurchaseAmount);
     error DcaManager__PurchasePeriodMustBeGreaterThanMinimum();
     error DcaManager__MinPurchasePeriodMustBeAtLeastOneDay();
+    error DcaManager__PurchasePeriodMustBeWholeDays();
     error DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance();
     error DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(uint256 timeRemaining);
     error DcaManager__InexistentScheduleIndex();

--- a/test/ai-generated/fuzz/Handler.t.sol
+++ b/test/ai-generated/fuzz/Handler.t.sol
@@ -103,6 +103,7 @@ contract Handler is Test {
         // Prevent pathological gas / overflow situations without shrinking search-space too much
         depositAmount  = bound(depositAmount,  MIN_DEPOSIT_AMOUNT,  INTERNAL_UPPER_AMOUNT);
         purchasePeriod = bound(purchasePeriod, MIN_PURCHASE_PERIOD, INTERNAL_UPPER_PERIOD);
+        purchasePeriod = (purchasePeriod / 1 days) * 1 days;
         purchaseAmount = bound(purchaseAmount, MIN_PURCHASE_AMOUNT, depositAmount / 2);
 
         // Mint enough tokens for the user and approve handler without arbitrary caps
@@ -255,6 +256,7 @@ contract Handler is Test {
         if (purchasePeriod > 0) {
             vm.assume(purchasePeriod >= MIN_PURCHASE_PERIOD);
             purchasePeriod = bound(purchasePeriod, MIN_PURCHASE_PERIOD, INTERNAL_UPPER_PERIOD);
+            purchasePeriod = (purchasePeriod / 1 days) * 1 days;
         }
 
         // Mint tokens for additional deposit if needed
@@ -539,7 +541,7 @@ contract Handler is Test {
      * @notice Test modifying minimum purchase period (owner-only)
      */
     function modifyMinPurchasePeriod(uint256 newMinPurchasePeriod) external {
-        newMinPurchasePeriod = bound(newMinPurchasePeriod, 1 days, 365 days);
+        newMinPurchasePeriod = bound(newMinPurchasePeriod, 1, 365) * 1 days;
         
         vm.startPrank(OWNER);
         try dcaManager.modifyMinPurchasePeriod(newMinPurchasePeriod) {

--- a/test/ai-generated/fuzz/Handler.t.sol
+++ b/test/ai-generated/fuzz/Handler.t.sol
@@ -539,7 +539,7 @@ contract Handler is Test {
      * @notice Test modifying minimum purchase period (owner-only)
      */
     function modifyMinPurchasePeriod(uint256 newMinPurchasePeriod) external {
-        newMinPurchasePeriod = bound(newMinPurchasePeriod, 1 hours, 365 days);
+        newMinPurchasePeriod = bound(newMinPurchasePeriod, 1 days, 365 days);
         
         vm.startPrank(OWNER);
         try dcaManager.modifyMinPurchasePeriod(newMinPurchasePeriod) {

--- a/test/unit/DcaConfigurationTest.t.sol
+++ b/test/unit/DcaConfigurationTest.t.sol
@@ -110,6 +110,28 @@ contract DcaConfigurationTest is DcaDappTest {
         dcaManager.setPurchasePeriod(address(stablecoin), SCHEDULE_INDEX, scheduleId, MIN_PURCHASE_PERIOD - 1);
     }
 
+    function testPurchasePeriodMustBeWholeDays() external {
+        vm.prank(USER);
+        bytes32 scheduleId = dcaManager.getMyScheduleId(address(stablecoin), SCHEDULE_INDEX);
+        vm.expectRevert(IDcaManager.DcaManager__PurchasePeriodMustBeWholeDays.selector);
+        vm.prank(USER);
+        dcaManager.setPurchasePeriod(address(stablecoin), SCHEDULE_INDEX, scheduleId, MIN_PURCHASE_PERIOD + 12 hours);
+    }
+
+    function testCreateDcaScheduleRevertsIfPeriodNotWholeDays() external {
+        vm.startPrank(USER);
+        stablecoin.approve(address(stablecoinHandler), AMOUNT_TO_DEPOSIT);
+        vm.expectRevert(IDcaManager.DcaManager__PurchasePeriodMustBeWholeDays.selector);
+        dcaManager.createDcaSchedule(
+            address(stablecoin),
+            AMOUNT_TO_DEPOSIT,
+            AMOUNT_TO_SPEND,
+            MIN_PURCHASE_PERIOD + 12 hours,
+            s_lendingProtocolIndex
+        );
+        vm.stopPrank();
+    }
+
     function testMaxSchedulesPerTokenCannotBeExceeded() external {
         uint256 maxSchedulesPerToken = dcaManager.getMaxSchedulesPerToken();
         bytes memory encodedRevert = abi.encodeWithSelector(

--- a/test/unit/ModifiersTest.t.sol
+++ b/test/unit/ModifiersTest.t.sol
@@ -4,8 +4,10 @@ pragma solidity 0.8.36;
 
 import {Test, console} from "forge-std/Test.sol";
 import {DcaDappTest} from "./DcaDappTest.t.sol";
+import {DcaManager} from "../../src/DcaManager.sol";
 import {IDcaManager} from "../../src/interfaces/IDcaManager.sol";
 import {ITokenHandler} from "../../src/interfaces/ITokenHandler.sol";
+import "../../script/Constants.sol";
 
 contract ModifiersTest is DcaDappTest {
     // Events
@@ -48,5 +50,25 @@ contract ModifiersTest is DcaDappTest {
         dcaManager.modifyMinPurchasePeriod(newMinPurchasePeriod);
         minPurchasePeriodAfter = dcaManager.getMinPurchasePeriod();
         assertEq(minPurchasePeriodAfter, newMinPurchasePeriod);
+    }
+
+    function testModifyMinPurchasePeriodRevertsBelowOneDay() external {
+        vm.prank(OWNER);
+        vm.expectRevert(IDcaManager.DcaManager__MinPurchasePeriodMustBeAtLeastOneDay.selector);
+        dcaManager.modifyMinPurchasePeriod(1 days - 1);
+        assertEq(dcaManager.getMinPurchasePeriod(), MIN_PURCHASE_PERIOD);
+    }
+
+    function testModifyMinPurchasePeriodAllowsOneDay() external {
+        vm.prank(OWNER);
+        dcaManager.modifyMinPurchasePeriod(2 days);
+        vm.prank(OWNER);
+        dcaManager.modifyMinPurchasePeriod(1 days);
+        assertEq(dcaManager.getMinPurchasePeriod(), 1 days);
+    }
+
+    function testConstructorRevertsIfMinPurchasePeriodBelowOneDay() external {
+        vm.expectRevert(IDcaManager.DcaManager__MinPurchasePeriodMustBeAtLeastOneDay.selector);
+        new DcaManager(address(operationsAdmin), 1 days - 1, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
     }
 }

--- a/test/unit/ModifiersTest.t.sol
+++ b/test/unit/ModifiersTest.t.sol
@@ -71,4 +71,16 @@ contract ModifiersTest is DcaDappTest {
         vm.expectRevert(IDcaManager.DcaManager__MinPurchasePeriodMustBeAtLeastOneDay.selector);
         new DcaManager(address(operationsAdmin), 1 days - 1, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
     }
+
+    function testModifyMinPurchasePeriodRevertsIfNotWholeDays() external {
+        vm.prank(OWNER);
+        vm.expectRevert(IDcaManager.DcaManager__PurchasePeriodMustBeWholeDays.selector);
+        dcaManager.modifyMinPurchasePeriod(1 days + 12 hours);
+        assertEq(dcaManager.getMinPurchasePeriod(), MIN_PURCHASE_PERIOD);
+    }
+
+    function testConstructorRevertsIfMinPurchasePeriodNotWholeDays() external {
+        vm.expectRevert(IDcaManager.DcaManager__PurchasePeriodMustBeWholeDays.selector);
+        new DcaManager(address(operationsAdmin), 1 days + 12 hours, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
+    }
 }

--- a/test/unit/RbtcPurchaseTest.t.sol
+++ b/test/unit/RbtcPurchaseTest.t.sol
@@ -888,13 +888,6 @@ contract RbtcPurchaseTest is DcaDappTest {
         returns (uint256)
     {
         uint256 periodsElapsed = (timestamp - lastPurchaseTimestamp) / purchasePeriod;
-        uint256 snapped = lastPurchaseTimestamp + periodsElapsed * purchasePeriod;
-        uint256 nextDueTimestamp = snapped + purchasePeriod;
-        uint256 nextPurchaseDayStart = _utcDayStart(nextDueTimestamp);
-        uint256 currentDayStart = _utcDayStart(timestamp);
-        if (currentDayStart >= nextPurchaseDayStart) {
-            snapped += purchasePeriod;
-        }
-        return snapped;
+        return lastPurchaseTimestamp + periodsElapsed * purchasePeriod;
     }
 }

--- a/test/unit/RbtcPurchaseTest.t.sol
+++ b/test/unit/RbtcPurchaseTest.t.sol
@@ -73,13 +73,25 @@ contract RbtcPurchaseTest is DcaDappTest {
         vm.prank(SWAPPER);
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
 
-        uint256 dueDayStart = _utcDayStart(firstBuy) + 1 days; // still 20 hours before last + period
+        uint256 dueDayStart = _utcDayStart(firstBuy) + 1 days;
         vm.warp(dueDayStart);
         vm.prank(SWAPPER);
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
 
         IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
-        assertEq(schedule.lastPurchaseTimestamp, firstBuy + MIN_PURCHASE_PERIOD);
+        assertEq(schedule.lastPurchaseTimestamp, _utcDayStart(firstBuy) + MIN_PURCHASE_PERIOD);
+    }
+
+    function testFirstPurchaseStampsUtcDayStart() external {
+        uint256 firstBuy = _nextUtcTimestamp(20 hours);
+        vm.warp(firstBuy);
+        bytes32 scheduleId = dcaManager.getScheduleId(USER, address(stablecoin), SCHEDULE_INDEX);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
+        assertEq(schedule.lastPurchaseTimestamp, _utcDayStart(firstBuy));
+        assertTrue(schedule.lastPurchaseTimestamp != 0);
     }
 
     function testCannotBuyOneSecondBeforeDueUtcDay() external {
@@ -113,7 +125,7 @@ contract RbtcPurchaseTest is DcaDappTest {
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
 
         IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
-        assertEq(schedule.lastPurchaseTimestamp, firstBuy + MIN_PURCHASE_PERIOD);
+        assertEq(schedule.lastPurchaseTimestamp, _utcDayStart(firstBuy) + MIN_PURCHASE_PERIOD);
 
         vm.warp(dueDayStart + 9 hours); // still the due UTC day
         bytes memory encodedRevert = abi.encodeWithSelector(
@@ -141,7 +153,7 @@ contract RbtcPurchaseTest is DcaDappTest {
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
 
         IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
-        assertEq(schedule.lastPurchaseTimestamp, firstBuy + weeklyPeriod);
+        assertEq(schedule.lastPurchaseTimestamp, _utcDayStart(firstBuy) + weeklyPeriod);
     }
 
     function testGapResumeOnDueUtcDayConsumesThatDaySlot() external {
@@ -158,7 +170,7 @@ contract RbtcPurchaseTest is DcaDappTest {
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
 
         IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
-        assertEq(schedule.lastPurchaseTimestamp, firstBuy + 3 * MIN_PURCHASE_PERIOD);
+        assertEq(schedule.lastPurchaseTimestamp, _utcDayStart(firstBuy) + 3 * MIN_PURCHASE_PERIOD);
 
         vm.warp(thirdDueDayStart + 9 hours);
         bytes memory encodedRevert = abi.encodeWithSelector(
@@ -205,21 +217,19 @@ contract RbtcPurchaseTest is DcaDappTest {
     function testLastPurchaseTimestampConsistencyWhenScheduleResumed(uint256 timeUntilResume) public {
         if (timeUntilResume < MIN_PURCHASE_PERIOD) return; // Avoid known revert
         if (timeUntilResume > 100 * 52 weeks) return; // Avoid overflows
-        uint256 firstPurchaseTimestamp = block.timestamp;
         bytes32 scheduleId = dcaManager.getScheduleId(USER, address(stablecoin), SCHEDULE_INDEX);
         vm.prank(SWAPPER);
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
-        
-        // Imagine after the first purchase, the schedule runs out of stablecoin and is resumed later 
-        vm.warp(vm.getBlockTimestamp() + timeUntilResume); 
-        
+        uint256 gridOrigin = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX].lastPurchaseTimestamp;
+
+        // Imagine after the first purchase, the schedule runs out of stablecoin and is resumed later
+        vm.warp(vm.getBlockTimestamp() + timeUntilResume);
+
         vm.prank(SWAPPER);
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
 
         IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
-        uint256 expectedLast = _snappedLastPurchaseTimestamp(
-            firstPurchaseTimestamp, MIN_PURCHASE_PERIOD, block.timestamp
-        );
+        uint256 expectedLast = _snappedLastPurchaseTimestamp(gridOrigin, MIN_PURCHASE_PERIOD, block.timestamp);
         assertEq(schedule.lastPurchaseTimestamp, expectedLast);
         assertLt(schedule.lastPurchaseTimestamp, block.timestamp + MIN_PURCHASE_PERIOD);
         assertGt(schedule.lastPurchaseTimestamp, block.timestamp - MIN_PURCHASE_PERIOD);
@@ -853,8 +863,10 @@ contract RbtcPurchaseTest is DcaDappTest {
     }
 
     function _nextUtcTimestamp(uint256 hourOfDay) private view returns (uint256) {
-        uint256 candidate = _utcDayStart(block.timestamp) + hourOfDay;
-        if (candidate < block.timestamp) {
+        // Skip unix day 0 so a 00:00 stamp cannot collide with the "never purchased" sentinel.
+        uint256 ts = block.timestamp < 1 days ? 1 days : block.timestamp;
+        uint256 candidate = _utcDayStart(ts) + hourOfDay;
+        if (candidate < ts) {
             candidate += 1 days;
         }
         return candidate;

--- a/test/unit/RbtcPurchaseTest.t.sol
+++ b/test/unit/RbtcPurchaseTest.t.sol
@@ -888,7 +888,6 @@ contract RbtcPurchaseTest is DcaDappTest {
         returns (uint256)
     {
         uint256 periodsElapsed = (timestamp - lastPurchaseTimestamp) / purchasePeriod;
-        if (periodsElapsed == 0) periodsElapsed = 1;
         uint256 snapped = lastPurchaseTimestamp + periodsElapsed * purchasePeriod;
         uint256 nextDueTimestamp = snapped + purchasePeriod;
         uint256 nextPurchaseDayStart = _utcDayStart(nextDueTimestamp);

--- a/test/unit/RbtcPurchaseTest.t.sol
+++ b/test/unit/RbtcPurchaseTest.t.sol
@@ -878,8 +878,7 @@ contract RbtcPurchaseTest is DcaDappTest {
         returns (uint256)
     {
         uint256 nextDueTimestamp = lastPurchaseTimestamp + purchasePeriod;
-        uint256 nextPurchaseDayStart = _utcDayStart(nextDueTimestamp);
-        return nextPurchaseDayStart - block.timestamp;
+        return nextDueTimestamp - block.timestamp;
     }
 
     function _snappedLastPurchaseTimestamp(uint256 lastPurchaseTimestamp, uint256 purchasePeriod, uint256 timestamp)

--- a/test/unit/RbtcPurchaseTest.t.sol
+++ b/test/unit/RbtcPurchaseTest.t.sol
@@ -144,6 +144,32 @@ contract RbtcPurchaseTest is DcaDappTest {
         assertEq(schedule.lastPurchaseTimestamp, firstBuy + weeklyPeriod);
     }
 
+    function testGapResumeOnDueUtcDayConsumesThatDaySlot() external {
+        uint256 firstBuy = _nextUtcTimestamp(20 hours);
+        vm.warp(firstBuy);
+        bytes32 scheduleId = dcaManager.getScheduleId(USER, address(stablecoin), SCHEDULE_INDEX);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        // Day 0 20:00, then resume at 00:00 UTC of the third due day (52h later, 2 wall-clock periods)
+        uint256 thirdDueDayStart = _utcDayStart(firstBuy) + 3 days;
+        vm.warp(thirdDueDayStart);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
+        assertEq(schedule.lastPurchaseTimestamp, firstBuy + 3 * MIN_PURCHASE_PERIOD);
+
+        vm.warp(thirdDueDayStart + 9 hours);
+        bytes memory encodedRevert = abi.encodeWithSelector(
+            IDcaManager.DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed.selector,
+            _secondsUntilDueUtcDayStart(schedule.lastPurchaseTimestamp, schedule.purchasePeriod)
+        );
+        vm.expectRevert(encodedRevert);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+    }
+
     function testSeveralPurchasesOneSchedule() external {
         uint256 numOfPurchases = 5;
 
@@ -191,10 +217,12 @@ contract RbtcPurchaseTest is DcaDappTest {
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
 
         IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
-        assertLe(schedule.lastPurchaseTimestamp, block.timestamp);
+        uint256 expectedLast = _snappedLastPurchaseTimestamp(
+            firstPurchaseTimestamp, MIN_PURCHASE_PERIOD, block.timestamp
+        );
+        assertEq(schedule.lastPurchaseTimestamp, expectedLast);
+        assertLt(schedule.lastPurchaseTimestamp, block.timestamp + MIN_PURCHASE_PERIOD);
         assertGt(schedule.lastPurchaseTimestamp, block.timestamp - MIN_PURCHASE_PERIOD);
-        uint256 periodsElapsed = (block.timestamp - firstPurchaseTimestamp) / MIN_PURCHASE_PERIOD;
-        assertEq(schedule.lastPurchaseTimestamp, firstPurchaseTimestamp + periodsElapsed * MIN_PURCHASE_PERIOD);
     }
 
     function testRevertPurchasetIfStablecoinRunsOut() external {
@@ -840,5 +868,22 @@ contract RbtcPurchaseTest is DcaDappTest {
         uint256 nextDueTimestamp = lastPurchaseTimestamp + purchasePeriod;
         uint256 nextPurchaseDayStart = _utcDayStart(nextDueTimestamp);
         return nextPurchaseDayStart - block.timestamp;
+    }
+
+    function _snappedLastPurchaseTimestamp(uint256 lastPurchaseTimestamp, uint256 purchasePeriod, uint256 timestamp)
+        private
+        pure
+        returns (uint256)
+    {
+        uint256 periodsElapsed = (timestamp - lastPurchaseTimestamp) / purchasePeriod;
+        if (periodsElapsed == 0) periodsElapsed = 1;
+        uint256 snapped = lastPurchaseTimestamp + periodsElapsed * purchasePeriod;
+        uint256 nextDueTimestamp = snapped + purchasePeriod;
+        uint256 nextPurchaseDayStart = _utcDayStart(nextDueTimestamp);
+        uint256 currentDayStart = _utcDayStart(timestamp);
+        if (currentDayStart >= nextPurchaseDayStart) {
+            snapped += purchasePeriod;
+        }
+        return snapped;
     }
 }

--- a/test/unit/RbtcPurchaseTest.t.sol
+++ b/test/unit/RbtcPurchaseTest.t.sol
@@ -56,13 +56,92 @@ contract RbtcPurchaseTest is DcaDappTest {
         vm.stopPrank();
         vm.prank(SWAPPER);
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId); // first purchase
+        IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
         bytes memory encodedRevert = abi.encodeWithSelector(
             IDcaManager.DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed.selector,
-            block.timestamp + MIN_PURCHASE_PERIOD - block.timestamp
+            _secondsUntilDueUtcDayStart(schedule.lastPurchaseTimestamp, schedule.purchasePeriod)
         );
         vm.expectRevert(encodedRevert);
         vm.prank(SWAPPER);
         dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId); // second purchase
+    }
+
+    function testBuyAllowedAtUtcDayStartOfDueDay() external {
+        uint256 firstBuy = _nextUtcTimestamp(20 hours);
+        vm.warp(firstBuy);
+        bytes32 scheduleId = dcaManager.getScheduleId(USER, address(stablecoin), SCHEDULE_INDEX);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        uint256 dueDayStart = _utcDayStart(firstBuy) + 1 days; // still 20 hours before last + period
+        vm.warp(dueDayStart);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
+        assertEq(schedule.lastPurchaseTimestamp, firstBuy + MIN_PURCHASE_PERIOD);
+    }
+
+    function testCannotBuyOneSecondBeforeDueUtcDay() external {
+        uint256 firstBuy = _nextUtcTimestamp(20 hours);
+        vm.warp(firstBuy);
+        bytes32 scheduleId = dcaManager.getScheduleId(USER, address(stablecoin), SCHEDULE_INDEX);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        uint256 dueDayStart = _utcDayStart(firstBuy) + 1 days;
+        vm.warp(dueDayStart - 1);
+        bytes memory encodedRevert = abi.encodeWithSelector(
+            IDcaManager.DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed.selector,
+            uint256(1)
+        );
+        vm.expectRevert(encodedRevert);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+    }
+
+    function testUtcDayEarlyBuyConsumesOnePeriodAndBlocksSameDaySecondBuy() external {
+        uint256 firstBuy = _nextUtcTimestamp(20 hours);
+        vm.warp(firstBuy);
+        bytes32 scheduleId = dcaManager.getScheduleId(USER, address(stablecoin), SCHEDULE_INDEX);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        uint256 dueDayStart = _utcDayStart(firstBuy) + 1 days;
+        vm.warp(dueDayStart); // 00:00 UTC of the due day, before last + period wall-clock
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
+        assertEq(schedule.lastPurchaseTimestamp, firstBuy + MIN_PURCHASE_PERIOD);
+
+        vm.warp(dueDayStart + 9 hours); // still the due UTC day
+        bytes memory encodedRevert = abi.encodeWithSelector(
+            IDcaManager.DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed.selector,
+            _secondsUntilDueUtcDayStart(schedule.lastPurchaseTimestamp, schedule.purchasePeriod)
+        );
+        vm.expectRevert(encodedRevert);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+    }
+
+    function testWeeklyBuyAllowedOnDueUtcDay() external {
+        uint256 weeklyPeriod = 7 days;
+        uint256 firstBuy = _nextUtcTimestamp(20 hours);
+        vm.warp(firstBuy);
+        bytes32 scheduleId = dcaManager.getScheduleId(USER, address(stablecoin), SCHEDULE_INDEX);
+        vm.prank(USER);
+        dcaManager.setPurchasePeriod(address(stablecoin), SCHEDULE_INDEX, scheduleId, weeklyPeriod);
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        uint256 dueDayStart = _utcDayStart(firstBuy) + weeklyPeriod;
+        vm.warp(dueDayStart); // due UTC day 00:00, 20 hours before last + period
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), SCHEDULE_INDEX, scheduleId);
+
+        IDcaManager.DcaDetails memory schedule = dcaManager.getDcaSchedules(USER, address(stablecoin))[SCHEDULE_INDEX];
+        assertEq(schedule.lastPurchaseTimestamp, firstBuy + weeklyPeriod);
     }
 
     function testSeveralPurchasesOneSchedule() external {
@@ -739,5 +818,27 @@ contract RbtcPurchaseTest is DcaDappTest {
             );
         }
         vm.stopPrank();
+    }
+
+    function _utcDayStart(uint256 timestamp) private pure returns (uint256) {
+        return timestamp - (timestamp % 1 days);
+    }
+
+    function _nextUtcTimestamp(uint256 hourOfDay) private view returns (uint256) {
+        uint256 candidate = _utcDayStart(block.timestamp) + hourOfDay;
+        if (candidate < block.timestamp) {
+            candidate += 1 days;
+        }
+        return candidate;
+    }
+
+    function _secondsUntilDueUtcDayStart(uint256 lastPurchaseTimestamp, uint256 purchasePeriod)
+        private
+        view
+        returns (uint256)
+    {
+        uint256 nextDueTimestamp = lastPurchaseTimestamp + purchasePeriod;
+        uint256 nextPurchaseDayStart = _utcDayStart(nextDueTimestamp);
+        return nextPurchaseDayStart - block.timestamp;
     }
 }


### PR DESCRIPTION
## Summary

Schedules become eligible once the UTC calendar day of `last + purchasePeriod` has started, so the swapper can run at a fixed UTC time instead of waiting out a late first buy. Purchase periods must be whole days and at least one day. First purchase stamps 00:00 UTC of that day; later purchases add whole periods from that midnight grid.

## Assigned relaunch task spec

- Spec: `docs/relaunch/R2-utc-purchase-period.md`
- R-item: R2 (PR 3)
- Stacked on: `main`

## Scope / out of scope

**In scope**

- UTC-day eligibility in `DcaManager._rBtcPurchaseChecksEffects` (`currentDayStart < last + period`; `last` and `period` are whole days, so no extra UTC-day rounding or `periodsElapsed` floor)
- Keep missed-period timestamp snap (`periodsElapsed * purchasePeriod`)
- First purchase stamps 00:00 UTC; `lastPurchaseTimestamp` stays on that UTC-day grid
- `_validateMinPurchasePeriod` on constructor and `modifyMinPurchasePeriod`; `_validatePurchasePeriod` requires whole days for user schedules

**Out of scope (not in this PR)**

- Fee model / R18 packing / R19 pause (PR 2)
- R7 / R11 / R14
- Event reshaping, storage packing, handler/SIP-0094 work
- Deploy broadcasts

## Files beyond the spec

- `foundry.toml` — local Anvil genesis timestamp `86400` so unix day 0 midnight cannot collide with the never-purchased sentinel
- `test/unit/DcaConfigurationTest.t.sol` — whole-day period reverts
- `test/ai-generated/fuzz/Handler.t.sol` — owner `modifyMinPurchasePeriod` and schedule periods snapped to whole days (previously bounded down to `1 hours`)
- `AGENTS.md` — match neighboring `_validate*` helpers instead of adding a modifier because the spec named one

## Tests run

```
SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus STABLECOIN_TYPE=DOC forge test --match-contract "RbtcPurchaseTest|ModifiersTest|DcaConfigurationTest"
make check
```

## ABI changes

- [x] Yes — new errors `DcaManager__MinPurchasePeriodMustBeAtLeastOneDay` and `DcaManager__PurchasePeriodMustBeWholeDays`. Existing `DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(uint256 timeRemaining)` kept; `timeRemaining` is seconds until 00:00 UTC of the due day (`last + period` on the midnight grid). No function or event signature changes.

## Deployment / script impact

- [x] None
- [ ] `script/` or deploy config changed (local/test only; this PR must not broadcast)
- [x] Cutover / frontend note: swapper may run at a fixed UTC time once the due calendar day has started. `lastPurchaseTimestamp` is the UTC-day grid (first buy's 00:00, then whole periods), not execution time. Indexers should use `PurchaseRbtc__RbtcBought` plus the log's `block.timestamp` for purchase history.

## Security considerations

Protocol invariants in `AGENTS.md` still hold. This spec does not change them. No assembly in the purchase path. rBTC still pays `msg.sender`.

## Reviewer checklist

- [ ] Matches the assigned spec (or is clearly not a relaunch item)
- [ ] No optional / further-review work unless the spec assigned it
- [ ] PR is small and behavior-scoped; no unrelated refactors
- [ ] Extra files beyond the spec are listed and justified
- [ ] Tests listed above were run locally
- [ ] GitHub Actions CI is green after the latest push
- [ ] Protocol invariants in `AGENTS.md` still hold unless the spec changed one
- [ ] No broadcast, live-chain interaction, or secrets in the diff