### PR TITLE
feat: DcaManager max-schedules, one-purchase, and rBTC getters (R7/R11/R14)

### DIFF
--- a/docs/relaunch/R7-dca-manager-small-fixes.md
+++ b/docs/relaunch/R7-dca-manager-small-fixes.md
@@ -1,6 +1,6 @@
 # R7 — DcaManager small fixes (R7, R11, R14)
 
-Status: **in progress** · Assigned: yes · Optional/further-review: no
+Status: **in progress** (GitHub #45) · Assigned: yes · Optional/further-review: no
 
 ## Objective
 

--- a/docs/relaunch/R7-dca-manager-small-fixes.md
+++ b/docs/relaunch/R7-dca-manager-small-fixes.md
@@ -1,0 +1,106 @@
+# R7 — DcaManager small fixes (R7, R11, R14)
+
+Status: **in progress** · Assigned: yes · Optional/further-review: no
+
+## Objective
+
+Fix three small user-facing `DcaManager` gaps: the max-schedules cap must hold after the owner lowers it, a schedule may be funded for exactly one purchase, and users can read accumulated rBTC through `DcaManager` without knowing handler addresses.
+
+## Background
+
+PR 4 bundles these because they are independent, small, and all live on `DcaManager` / `IDcaManager`.
+
+**R7:** `createDcaSchedule` uses `if (numOfSchedules == s_maxSchedulesPerToken)`. That only fires while length grows up to the current cap. If the owner later lowers the cap via `modifyMaxSchedulesPerToken` below a user’s current count, `length == newMax` is false forever and that user can create an unbounded number of extra schedules. Existing tests hide this: they grow from 0 (or one setUp schedule) up to the current max, so `==` happens to fire.
+
+**R11:** `_validatePurchaseAmount` reverts if `purchaseAmount > tokenBalance / 2`, so create / update / `setPurchaseAmount` require current funds to cover two buys. That is a product preference, not a safety invariant. After the first buy of a 2× schedule the remaining balance already equals one purchase. `minPurchaseAmount` (default 25 DOC) stays as the dust/fee floor.
+
+**R14:** rBTC is stored per handler (`PurchaseRbtc.s_usersAccumulatedRbtc`). Users already withdraw through `DcaManager`; they should not have to resolve handler addresses to **read** the same balance. Interest already has this pattern (`getInterestAccrued` / `getMyInterestAccrued`). There is no single protocol-wide number unless the caller names every token × protocol pair.
+
+## Open product decisions
+
+**none**
+
+## Scope
+
+- [x] **R7:** In `createDcaSchedule`, change `if (numOfSchedules == s_maxSchedulesPerToken)` to `>=`. Keep `DcaManager__MaxSchedulesPerTokenReached`.
+
+- [x] **R11:** In `_validatePurchaseAmount`, drop `purchaseAmount > tokenBalance / 2` and `DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance`. Keep `purchaseAmount >= minPurchaseAmount`. Replace the upper bound with `purchaseAmount > tokenBalance` (exactly one purchase allowed). New error `DcaManager__PurchaseAmountExceedsBalance(address token, uint256 purchaseAmount, uint256 tokenBalance)`. Call sites unchanged: `createDcaSchedule` (balance = `depositAmount`), `setPurchaseAmount` (current schedule balance), `updateDcaSchedule` (balance after optional extra deposit). Update the `setPurchaseAmount` natspec that still says “half of the deposited amount.” Do not allow `purchaseAmount > tokenBalance`.
+
+- [x] **R14:** Add thin view wrappers on `DcaManager` / `IDcaManager`:
+
+  ```solidity
+  getAccumulatedRbtcBalance(address user, address token, uint256 lendingProtocolIndex) view returns (uint256)
+  getMyAccumulatedRbtcBalance(address token, uint256 lendingProtocolIndex) view returns (uint256)
+  ```
+
+  Delegate to `IPurchaseRbtc(address(_handler(token, lendingProtocolIndex))).getAccumulatedRbtcBalance(user)`. Missing handler: same as `_handler` today (`TokenNotAccepted`). Do not return 0 to hide a bad token/protocol pair. Keep `IPurchaseRbtc.getAccumulatedRbtcBalance`. No storage move. No no-arg “all my rBTC” enumerator.
+
+## Out of scope
+
+- [ ] Optional summing getter `getAccumulatedRbtcBalance(user, tokens[], indexes[])`.
+- [ ] Fee model, R18 packing, R19 pause, R12/R13/optionals (PR 2 / later PRs).
+- [ ] R8 `withdrawStuckRbtc` / `to` parameter.
+- [ ] Event reshaping, storage packing, pause.
+- [ ] Handler / accounting / SIP-0094 work (R1, R20).
+- [ ] `forge fmt` of existing files.
+- [ ] Deploy broadcasts or live addresses.
+- [ ] `dca-out-contracts`.
+
+## Files likely touched
+
+- `src/DcaManager.sol`
+- `src/interfaces/IDcaManager.sol`
+- `test/unit/DcaConfigurationTest.t.sol`
+- `test/ai-generated/unit/GettersTest.t.sol`
+
+Implementer may follow failing tests into `test/ai-generated/unit/DcaManagerEdgeCasesTest.t.sol` and `test/ai-generated/fuzz/Handler.t.sol` (`assume(purchaseAmount <= depositAmount / 2)` → `<= depositAmount`; `MIN_DEPOSIT_AMOUNT` is currently `MIN_PURCHASE_AMOUNT * 2` because of the old two-purchase rule). Extra files belong in the PR write-up.
+
+## Required tests
+
+Commands (targeted first, then done-gate):
+
+```bash
+SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus forge test --match-contract DcaConfigurationTest
+SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus forge test --match-contract GettersTest
+SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus forge test --match-contract DcaManagerEdgeCasesTest
+LENDING_PROTOCOL=tropykus SWAP_TYPE=mocSwaps forge test --match-contract InvariantTest
+make check
+```
+
+Behaviors to assert:
+
+- Growing from 0 (or one setUp schedule) to max still stops at max (`testMaxSchedulesPerTokenCannotBeExceeded` keeps passing).
+- After `modifyMaxSchedulesPerToken` to a value `<` current length, further `createDcaSchedule` reverts; it does not allow more schedules.
+- Create with `deposit == purchaseAmount >= min` succeeds; one `buyRbtc` empties the schedule.
+- `purchaseAmount` equal to current/deposit balance succeeds on `setPurchaseAmount` / create.
+- `purchaseAmount >` current/deposit balance reverts with `DcaManager__PurchaseAmountExceedsBalance`.
+- `purchaseAmount < minPurchaseAmount` still reverts.
+- No remaining `/ 2` purchase-amount check in `src/`.
+- Manager getter equals handler getter for the same user/token/protocol.
+- `getMyAccumulatedRbtcBalance` uses `msg.sender`.
+- Unknown token/protocol reverts on the single getter (`TokenNotAccepted`).
+
+Fork tests: not required.
+
+## Success criteria
+
+- [x] Growing to max still stops at max; lowering the cap below current length blocks further creates.
+- [x] A schedule funded for exactly one purchase can be created and emptied by one buy.
+- [x] `purchaseAmount >` balance still reverts; `< min` still reverts; no `/ 2` check remains in `src/`.
+- [x] `DcaManager` accumulated-rBTC getters match the handler for the same user/token/protocol; unknown pairs revert; `getMy*` uses `msg.sender`.
+- [x] Targeted tests above pass; `make check` passes.
+- [x] Protocol invariants in `AGENTS.md` unchanged.
+
+## Reviewer checklist
+
+- [ ] Matches **Scope**; nothing from **Out of scope**.
+- [ ] Protocol invariants in `AGENTS.md` still hold (this spec does not change them).
+- [ ] Tests in the PR match **Required tests**.
+- [ ] Files beyond this list are limited to direct dependencies / failing-test fallout and are named in the PR.
+- [ ] No unrelated refactors; history is reviewable.
+
+## ABI / deploy / cutover impact
+
+- ABI: remove `DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance`. Add `DcaManager__PurchaseAmountExceedsBalance(address token, uint256 purchaseAmount, uint256 tokenBalance)`. Add `getAccumulatedRbtcBalance(address,address,uint256)` and `getMyAccumulatedRbtcBalance(address,uint256)`. No event changes.
+- Scripts: none.
+- Cutover: frontend may drop the on-chain two-purchase assumption (optional UX warning when deposit `< 2 * purchaseAmount` is out of this repo). Frontend can read accumulated rBTC via `DcaManager` instead of resolving handlers. Do not lower `maxSchedulesPerToken` on the **live** DcaManager until this deployment; the `==` bug is why. Do not include broadcast steps.

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -22,5 +22,5 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 
 - Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub [#42](https://github.com/BitChillRSK/dca-contracts/pull/42)). Rootstock testnet accepted solc 0.8.36 / `cancun`.
 - Assigned: [R2-utc-purchase-period.md](./R2-utc-purchase-period.md) (PR 3, GitHub [#44](https://github.com/BitChillRSK/dca-contracts/pull/44)). No product gates. Does not wait on PR 2.
-- Assigned: [R7-dca-manager-small-fixes.md](./R7-dca-manager-small-fixes.md) (PR 4, stacked on [#44](https://github.com/BitChillRSK/dca-contracts/pull/44)). Bundles R7 / R11 / R14. No product gates.
-- Next unassigned: after this PR opens. PR 2 (decision record) stays available when the human wants to record fee / R18 / R19.
+- Assigned: [R7-dca-manager-small-fixes.md](./R7-dca-manager-small-fixes.md) (PR 4, GitHub [#45](https://github.com/BitChillRSK/dca-contracts/pull/45)). Bundles R7 / R11 / R14. No product gates. Stacked on [#44](https://github.com/BitChillRSK/dca-contracts/pull/44).
+- Next unassigned: `Start with R3` (PR 5, fee handling: R3 / R4 / R5). Ask fee model if PR 2 did not record it. PR 2 (decision record) stays available when the human wants to record fee / R18 / R19.

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -22,4 +22,5 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 
 - Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub [#42](https://github.com/BitChillRSK/dca-contracts/pull/42)). Rootstock testnet accepted solc 0.8.36 / `cancun`.
 - Assigned: [R2-utc-purchase-period.md](./R2-utc-purchase-period.md) (PR 3, GitHub [#44](https://github.com/BitChillRSK/dca-contracts/pull/44)). No product gates. Does not wait on PR 2.
-- Next unassigned: `Start with R7` (PR 4, DcaManager small fixes: R7 / R11 / R14). No product gates. PR 2 (decision record) stays available when the human wants to record fee / R18 / R19.
+- Assigned: [R7-dca-manager-small-fixes.md](./R7-dca-manager-small-fixes.md) (PR 4, stacked on [#44](https://github.com/BitChillRSK/dca-contracts/pull/44)). Bundles R7 / R11 / R14. No product gates.
+- Next unassigned: after this PR opens. PR 2 (decision record) stays available when the human wants to record fee / R18 / R19.

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -113,7 +113,7 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
      * @param scheduleIndex the schedule index
      * @param scheduleId the schedule id for validation
      * @param purchaseAmount the amount of stablecoin to swap periodically for rBTC
-     * @notice the amount cannot be greater than or equal to half of the deposited amount
+     * @notice the amount cannot exceed the schedule's current token balance
      */
     function setPurchaseAmount(address token, uint256 scheduleIndex, bytes32 scheduleId, uint256 purchaseAmount)
         external
@@ -168,7 +168,7 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
 
         DcaDetails[] storage schedules = s_dcaSchedules[msg.sender][token];
         uint256 numOfSchedules = schedules.length;
-        if (numOfSchedules == s_maxSchedulesPerToken) {
+        if (numOfSchedules >= s_maxSchedulesPerToken) {
             revert DcaManager__MaxSchedulesPerTokenReached(token);
         }
 
@@ -494,11 +494,8 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
         if (purchaseAmount < minPurchaseAmount) {
             revert DcaManager__PurchaseAmountMustBeGreaterThanMinimum(token, minPurchaseAmount);
         }
-        /**
-         * @notice Purchase amount must be at least twice the balance of the token in the contract to allow at least two DCA purchases
-         */
-        if (purchaseAmount > (tokenBalance) / 2) {
-            revert DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance();
+        if (purchaseAmount > tokenBalance) {
+            revert DcaManager__PurchaseAmountExceedsBalance(token, purchaseAmount, tokenBalance);
         }
     }
 
@@ -835,6 +832,37 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
      */
     function getMyInterestAccrued(address token, uint256 lendingProtocolIndex) external view override returns (uint256) {
         return getInterestAccrued(msg.sender, token, lendingProtocolIndex);
+    }
+
+    /**
+     * @notice get the rBTC accumulated by a user on the handler for a token and lending protocol
+     * @param user: the user to get the accumulated rBTC for
+     * @param token: the token
+     * @param lendingProtocolIndex: the lending protocol index
+     * @return the accumulated rBTC balance
+     */
+    function getAccumulatedRbtcBalance(address user, address token, uint256 lendingProtocolIndex)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        return IPurchaseRbtc(address(_handler(token, lendingProtocolIndex))).getAccumulatedRbtcBalance(user);
+    }
+
+    /**
+     * @notice get the rBTC accumulated by the caller on the handler for a token and lending protocol
+     * @param token: the token
+     * @param lendingProtocolIndex: the lending protocol index
+     * @return the accumulated rBTC balance
+     */
+    function getMyAccumulatedRbtcBalance(address token, uint256 lendingProtocolIndex)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return getAccumulatedRbtcBalance(msg.sender, token, lendingProtocolIndex);
     }
 
     /**

--- a/src/interfaces/IDcaManager.sol
+++ b/src/interfaces/IDcaManager.sol
@@ -64,7 +64,7 @@ interface IDcaManager {
     error DcaManager__PurchaseAmountMustBeGreaterThanMinimum(address token, uint256 minPurchaseAmount);
     error DcaManager__PurchasePeriodMustBeGreaterThanMinimum();
     error DcaManager__MinPurchasePeriodMustBeAtLeastOneDay();
-    error DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance();
+    error DcaManager__PurchaseAmountExceedsBalance(address token, uint256 purchaseAmount, uint256 tokenBalance);
     error DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(uint256 timeRemaining);
     error DcaManager__InexistentScheduleIndex();
     error DcaManager__ScheduleIdAndIndexMismatch();
@@ -361,6 +361,26 @@ interface IDcaManager {
      * @return the interest accrued by the user for the token and lending protocol index
      */
     function getMyInterestAccrued(address token, uint256 lendingProtocolIndex) external view returns (uint256);
+
+    /**
+     * @notice get the rBTC accumulated by a user on the handler for a token and lending protocol index
+     * @param user the user address
+     * @param token the token address
+     * @param lendingProtocolIndex the lending protocol index
+     * @return the accumulated rBTC balance
+     */
+    function getAccumulatedRbtcBalance(address user, address token, uint256 lendingProtocolIndex)
+        external
+        view
+        returns (uint256);
+
+    /**
+     * @notice get the rBTC accumulated by the caller on the handler for a token and lending protocol index
+     * @param token the token address
+     * @param lendingProtocolIndex the lending protocol index
+     * @return the accumulated rBTC balance
+     */
+    function getMyAccumulatedRbtcBalance(address token, uint256 lendingProtocolIndex) external view returns (uint256);
 
     /**
      * @dev returns the minimum period that can be set for purchases

--- a/test/ai-generated/fuzz/Handler.t.sol
+++ b/test/ai-generated/fuzz/Handler.t.sol
@@ -42,7 +42,7 @@ contract Handler is Test {
     //  require() checks so that handler calls never revert when `fail_on_revert`
     //  is active.  No arbitrary upper caps – we rely on vm.assume instead.
     // ----------------------------------------------------------------------------
-    uint256 constant MIN_DEPOSIT_AMOUNT   = MIN_PURCHASE_AMOUNT * 2; // protocol-level rule
+    uint256 constant MIN_DEPOSIT_AMOUNT   = MIN_PURCHASE_AMOUNT;
 
     // Upper-bound safety helpers (prevent overflow / gas OOM without masking logic)
     uint256 constant INTERNAL_UPPER_AMOUNT = 1e32;   // ≈ 10^14 ether – far above realistic amounts
@@ -98,12 +98,12 @@ contract Handler is Test {
         vm.assume(depositAmount >= MIN_DEPOSIT_AMOUNT);
         vm.assume(purchasePeriod >= MIN_PURCHASE_PERIOD);
         vm.assume(purchaseAmount >= MIN_PURCHASE_AMOUNT);
-        vm.assume(purchaseAmount <= depositAmount / 2);
+        vm.assume(purchaseAmount <= depositAmount);
 
         // Prevent pathological gas / overflow situations without shrinking search-space too much
         depositAmount  = bound(depositAmount,  MIN_DEPOSIT_AMOUNT,  INTERNAL_UPPER_AMOUNT);
         purchasePeriod = bound(purchasePeriod, MIN_PURCHASE_PERIOD, INTERNAL_UPPER_PERIOD);
-        purchaseAmount = bound(purchaseAmount, MIN_PURCHASE_AMOUNT, depositAmount / 2);
+        purchaseAmount = bound(purchaseAmount, MIN_PURCHASE_AMOUNT, depositAmount);
 
         // Mint enough tokens for the user and approve handler without arbitrary caps
         uint256 userBalance = stablecoin.balanceOf(user);
@@ -248,7 +248,7 @@ contract Handler is Test {
         if (purchaseAmount > 0) {
             vm.assume(purchaseAmount >= MIN_PURCHASE_AMOUNT);
             // Must also satisfy _validatePurchaseAmount
-            vm.assume(purchaseAmount <= schedules[scheduleIndex].tokenBalance / 2 + depositAmount / 2);
+            vm.assume(purchaseAmount <= schedules[scheduleIndex].tokenBalance + depositAmount);
             purchaseAmount = bound(purchaseAmount, MIN_PURCHASE_AMOUNT, INTERNAL_UPPER_AMOUNT);
         }
 

--- a/test/ai-generated/unit/DcaManagerEdgeCasesTest.t.sol
+++ b/test/ai-generated/unit/DcaManagerEdgeCasesTest.t.sol
@@ -223,13 +223,19 @@ contract DcaManagerEdgeCasesTest is Test {
     }
     
     function test_buyRbtc_reverts_insufficientBalance() public {
-        // Create schedule with purchase amount equal to more than half of deposit (should fail validation)
-        vm.expectRevert(IDcaManager.DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance.selector);
+        // Create schedule with purchase amount above the deposit (should fail validation)
+        bytes memory encodedRevert = abi.encodeWithSelector(
+            IDcaManager.DcaManager__PurchaseAmountExceedsBalance.selector,
+            address(stablecoin),
+            501 ether,
+            500 ether
+        );
+        vm.expectRevert(encodedRevert);
         vm.prank(USER);
         dcaManager.createDcaSchedule(
             address(stablecoin),
-            500 ether,  // depositAmount 
-            300 ether, // purchaseAmount (more than half of deposit)
+            500 ether,  // depositAmount
+            501 ether, // purchaseAmount exceeds deposit
             MIN_PURCHASE_PERIOD,
             TROPYKUS_INDEX
         );
@@ -575,11 +581,18 @@ contract DcaManagerEdgeCasesTest is Test {
             TROPYKUS_INDEX
         );
         
-        // Test with invalid purchase amounts (more than half of deposit)
+        // Test with invalid purchase amounts (more than deposit)
         uint256 deposit = bound(seed, 100 ether, 1000 ether);
-        uint256 purchaseAmount = deposit / 2 + 1; // More than half
-        
-        vm.expectRevert(IDcaManager.DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance.selector);
+        uint256 purchaseAmount = deposit + 1;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IDcaManager.DcaManager__PurchaseAmountExceedsBalance.selector,
+                address(stablecoin),
+                purchaseAmount,
+                deposit
+            )
+        );
         vm.prank(USER);
         dcaManager.createDcaSchedule(
             address(stablecoin),

--- a/test/ai-generated/unit/GettersTest.t.sol
+++ b/test/ai-generated/unit/GettersTest.t.sol
@@ -114,6 +114,35 @@ contract GettersTest is DcaDappTest {
         assertEq(maxSchedules, MAX_SCHEDULES_PER_TOKEN);
     }
 
+    function test_dcaManager_getAccumulatedRbtcBalance_matchesHandler() public {
+        super.makeSinglePurchase();
+        uint256 fromManager =
+            dcaManager.getAccumulatedRbtcBalance(USER, address(stablecoin), s_lendingProtocolIndex);
+        uint256 fromHandler = IPurchaseRbtc(address(stablecoinHandler)).getAccumulatedRbtcBalance(USER);
+        assertEq(fromManager, fromHandler);
+        assertGt(fromManager, 0);
+    }
+
+    function test_dcaManager_getMyAccumulatedRbtcBalance_usesMsgSender() public {
+        super.makeSinglePurchase();
+        vm.prank(USER);
+        uint256 mine = dcaManager.getMyAccumulatedRbtcBalance(address(stablecoin), s_lendingProtocolIndex);
+        vm.prank(OWNER);
+        uint256 owners = dcaManager.getMyAccumulatedRbtcBalance(address(stablecoin), s_lendingProtocolIndex);
+        assertEq(mine, IPurchaseRbtc(address(stablecoinHandler)).getAccumulatedRbtcBalance(USER));
+        assertEq(owners, 0);
+        assertGt(mine, 0);
+    }
+
+    function test_dcaManager_getAccumulatedRbtcBalance_reverts_unknownTokenProtocol() public {
+        address unknownToken = makeAddr("unknownToken");
+        bytes memory encodedRevert = abi.encodeWithSelector(
+            IDcaManager.DcaManager__TokenNotAccepted.selector, unknownToken, s_lendingProtocolIndex
+        );
+        vm.expectRevert(encodedRevert);
+        dcaManager.getAccumulatedRbtcBalance(USER, unknownToken, s_lendingProtocolIndex);
+    }
+
     function test_dcaManager_getMyInterestAccrued_whenSupported() public {
         // Only test if the lending protocol supports interest
         if (s_lendingProtocolIndex > 0) {

--- a/test/unit/DcaConfigurationTest.t.sol
+++ b/test/unit/DcaConfigurationTest.t.sol
@@ -83,12 +83,46 @@ contract DcaConfigurationTest is DcaDappTest {
         assertEq(MAX_SCHEDULES_PER_TOKEN, dcaManager.getMaxSchedulesPerToken());
     }
 
-    function testPurchaseAmountCannotBeMoreThanHalfBalance() external {
+    function testPurchaseAmountEqualToBalanceSucceeds() external {
+        vm.startPrank(USER);
+        bytes32 scheduleId = dcaManager.getMyScheduleId(address(stablecoin), SCHEDULE_INDEX);
+        dcaManager.setPurchaseAmount(address(stablecoin), SCHEDULE_INDEX, scheduleId, AMOUNT_TO_DEPOSIT);
+        assertEq(AMOUNT_TO_DEPOSIT, dcaManager.getMySchedulePurchaseAmount(address(stablecoin), SCHEDULE_INDEX));
+        vm.stopPrank();
+    }
+
+    function testPurchaseAmountCannotExceedBalance() external {
         vm.prank(USER);
         bytes32 scheduleId = dcaManager.getMyScheduleId(address(stablecoin), SCHEDULE_INDEX);
-        vm.expectRevert(IDcaManager.DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance.selector);
+        bytes memory encodedRevert = abi.encodeWithSelector(
+            IDcaManager.DcaManager__PurchaseAmountExceedsBalance.selector,
+            address(stablecoin),
+            AMOUNT_TO_DEPOSIT + 1,
+            AMOUNT_TO_DEPOSIT
+        );
+        vm.expectRevert(encodedRevert);
         vm.prank(USER);
-        dcaManager.setPurchaseAmount(address(stablecoin), SCHEDULE_INDEX, scheduleId, AMOUNT_TO_DEPOSIT / 2 + 1);
+        dcaManager.setPurchaseAmount(address(stablecoin), SCHEDULE_INDEX, scheduleId, AMOUNT_TO_DEPOSIT + 1);
+    }
+
+    function testCreateScheduleFundedForExactlyOnePurchase() external {
+        uint256 onePurchaseAmount = AMOUNT_TO_SPEND;
+        vm.startPrank(USER);
+        stablecoin.approve(address(stablecoinHandler), onePurchaseAmount);
+        dcaManager.createDcaSchedule(
+            address(stablecoin), onePurchaseAmount, onePurchaseAmount, MIN_PURCHASE_PERIOD, s_lendingProtocolIndex
+        );
+        uint256 scheduleIndex = 1; // setUp already created schedule 0
+        bytes32 scheduleId = dcaManager.getMyScheduleId(address(stablecoin), scheduleIndex);
+        assertEq(onePurchaseAmount, dcaManager.getMyScheduleTokenBalance(address(stablecoin), scheduleIndex));
+        assertEq(onePurchaseAmount, dcaManager.getMySchedulePurchaseAmount(address(stablecoin), scheduleIndex));
+        vm.stopPrank();
+
+        vm.prank(SWAPPER);
+        dcaManager.buyRbtc(USER, address(stablecoin), scheduleIndex, scheduleId);
+
+        vm.prank(USER);
+        assertEq(0, dcaManager.getMyScheduleTokenBalance(address(stablecoin), scheduleIndex));
     }
 
     function testPurchaseAmountMustBeGreaterThanMin() external {
@@ -126,6 +160,36 @@ contract DcaConfigurationTest is DcaDappTest {
             );
             vm.stopPrank();
         }
+    }
+
+    function testCreateRevertsAfterOwnerLowersMaxBelowCurrentCount() external {
+        uint256 maxSchedulesPerToken = dcaManager.getMaxSchedulesPerToken();
+        // setUp already created one schedule; fill up to the current max
+        for (uint256 i = 1; i < maxSchedulesPerToken; ++i) {
+            vm.startPrank(USER);
+            stablecoin.approve(address(stablecoinHandler), AMOUNT_TO_DEPOSIT);
+            dcaManager.createDcaSchedule(
+                address(stablecoin), AMOUNT_TO_DEPOSIT / 2, AMOUNT_TO_SPEND, MIN_PURCHASE_PERIOD, s_lendingProtocolIndex
+            );
+            vm.stopPrank();
+        }
+        vm.prank(USER);
+        assertEq(maxSchedulesPerToken, dcaManager.getMyDcaSchedules(address(stablecoin)).length);
+
+        uint256 loweredMax = maxSchedulesPerToken - 1;
+        vm.prank(OWNER);
+        dcaManager.modifyMaxSchedulesPerToken(loweredMax);
+
+        bytes memory encodedRevert = abi.encodeWithSelector(
+            IDcaManager.DcaManager__MaxSchedulesPerTokenReached.selector, address(stablecoin)
+        );
+        vm.startPrank(USER);
+        stablecoin.approve(address(stablecoinHandler), AMOUNT_TO_DEPOSIT);
+        vm.expectRevert(encodedRevert);
+        dcaManager.createDcaSchedule(
+            address(stablecoin), AMOUNT_TO_DEPOSIT / 2, AMOUNT_TO_SPEND, MIN_PURCHASE_PERIOD, s_lendingProtocolIndex
+        );
+        vm.stopPrank();
     }
 
     ///////////////////////////////


### PR DESCRIPTION
## Summary

Fixes three small `DcaManager` gaps: the max-schedules cap now holds after the owner lowers it (`>=` instead of `==`), a schedule may be funded for exactly one purchase, and users can read accumulated rBTC through `DcaManager` without resolving handler addresses.

## Assigned relaunch task spec

- Spec: `docs/relaunch/R7-dca-manager-small-fixes.md`
- R-item (if any): R7, R11, R14 (PR 4)
- Stacked on: `feat/r2-utc-purchase-period` ([#44](https://github.com/BitChillRSK/dca-contracts/pull/44))

## Scope / out of scope

**In scope**

- R7: `createDcaSchedule` max-schedules check uses `>=`.
- R11: drop the on-chain two-purchase (`/ 2`) rule; allow `purchaseAmount == tokenBalance`; revert when it exceeds balance.
- R14: add `getAccumulatedRbtcBalance` / `getMyAccumulatedRbtcBalance` on `DcaManager`, delegating to the handler.

**Out of scope (not in this PR)**

- Optional summing getter over token/protocol arrays
- Fee model, R18 packing, R19 pause, R12/R13
- R8 `withdrawStuckRbtc` / `to` parameter
- Event reshaping, storage packing, pause
- Handler / accounting / SIP-0094 (R1, R20)
- `forge fmt`, deploy broadcasts, `dca-out-contracts`

## Files beyond the spec

- `test/ai-generated/unit/DcaManagerEdgeCasesTest.t.sol` — existing tests expected the removed half-balance error
- `test/ai-generated/fuzz/Handler.t.sol` — fuzz assumes and `MIN_DEPOSIT_AMOUNT` still encoded the two-purchase rule

## Tests run

```
SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus STABLECOIN_TYPE=DOC forge test --match-contract "DcaConfigurationTest|GettersTest|DcaManagerEdgeCasesTest"
LENDING_PROTOCOL=tropykus SWAP_TYPE=mocSwaps STABLECOIN_TYPE=DOC forge test --match-contract InvariantTest
make check
```

## ABI changes

- [ ] None
- [x] Yes — remove `DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance`. Add `DcaManager__PurchaseAmountExceedsBalance(address token, uint256 purchaseAmount, uint256 tokenBalance)`. Add `getAccumulatedRbtcBalance(address,address,uint256)` and `getMyAccumulatedRbtcBalance(address,uint256)`. No event changes.

## Deployment / script impact

- [x] None
- [ ] `script/` or deploy config changed (local/test only; this PR must not broadcast)
- [x] Cutover / frontend note: frontend may drop the on-chain two-purchase assumption (optional UX warning when deposit `< 2 * purchaseAmount` is out of this repo). Frontend can read accumulated rBTC via `DcaManager`. Do not lower `maxSchedulesPerToken` on the **live** DcaManager until this deployment.

## Security considerations

Protocol invariants in `AGENTS.md` are unchanged. rBTC withdrawals still pay `msg.sender` only; this PR adds view getters, not a `to` parameter. The max-schedules `>=` check closes an unbounded-create path after the owner lowers the cap.

## Reviewer checklist

- [ ] Matches the assigned spec (or is clearly not a relaunch item)
- [ ] No optional / further-review work unless the spec assigned it
- [ ] PR is small and behavior-scoped; no unrelated refactors
- [ ] Extra files beyond the spec are listed and justified
- [ ] Tests listed above were run locally
- [ ] GitHub Actions CI is green after the latest push
- [ ] Protocol invariants in `AGENTS.md` still hold unless the spec changed one
- [ ] No broadcast, live-chain interaction, or secrets in the diff

Made with [Cursor](https://cursor.com)