### PR TITLE
fix: FeeHandler combined setter, bound checks, and batch fee load (R3/R4/R5)

### DIFF
--- a/docs/relaunch/R3-fee-handling.md
+++ b/docs/relaunch/R3-fee-handling.md
@@ -1,6 +1,6 @@
 # R3 — FeeHandler linear-fee fixes (R3, R4, R5)
 
-Status: **in progress** · Assigned: yes · Optional/further-review: no
+Status: **in progress** (GitHub #46) · Assigned: yes · Optional/further-review: no
 
 ## Objective
 

--- a/docs/relaunch/R3-fee-handling.md
+++ b/docs/relaunch/R3-fee-handling.md
@@ -1,0 +1,118 @@
+# R3 — FeeHandler linear-fee fixes (R3, R4, R5)
+
+Status: **in progress** · Assigned: yes · Optional/further-review: no
+
+## Objective
+
+Keep the linear fee model. Make `setFeeRateParams` able to raise the rate band in one call, keep purchase-bound invariants on the individual setters, and load fee storage once per batch so interpolation math does not re-SLOAD on every purchase.
+
+## Background
+
+PR 5 bundles R3, R4, and R5 because they are isolated `FeeHandler` work and all apply only if the linear model stays. Product gate (this chat): **keep linear**. Do not flatten to one rate.
+
+Linear means: `maxFeeRate` at or below `feePurchaseLowerBound`, `minFeeRate` at or above `feePurchaseUpperBound`, straight interpolation in between. Equal min and max is a valid flat rate (production is 100/100). There is no on-chain cap on `maxFeeRate`; do not add one.
+
+**R3:** `setFeeRateParams` validates `newMin ≤ newMax`, then calls `setMinFeeRate` first. That setter compares against the **live** `s_maxFeeRate`, not the new max. Raising the band in one call (e.g. 100/200 → 250/400) reverts even though the new pair is valid. Individual min/max setters already keep `min ≤ max` against the other live rate (`f07c57b` / `eaca027`). Combined bound check is already `>=`.
+
+**R4:** Combined setter requires `lower < upper`, but `setPurchaseLowerBound` / `setPurchaseUpperBound` still write without comparing to the other live bound, so `lower ≥ upper` can be stored.
+
+**R5:** `_calculateFeeAndNetAmounts` calls `_calculateFee` per item. `_calculateFee` is `view` and SLOAD’s the four fee fields on every iteration. Those values do not change during the tx.
+
+`PurchaseMoc` / `PurchaseUniswap` keep calling `_calculateFee` / `_calculateFeeAndNetAmounts`. Do not change fee rates, interpolation, or which path (`buyRbtc` vs batch) is used.
+
+## Open product decisions
+
+**none** — keep linear (answered this chat). Flatten is out of scope.
+
+## Scope
+
+- [ ] **R3:** After validating the new pair, write rates and bounds in `setFeeRateParams` instead of routing through the individual setters. Keep the existing pair checks (`minFeeRate > maxFeeRate`, `feePurchaseLowerBound >= feePurchaseUpperBound`). Only write/emit a field when it changes (same as today’s `if (s_* != new)`). Individual setters stay for one-sided updates.
+
+- [ ] **R4:** On `setPurchaseLowerBound` / `setPurchaseUpperBound`, validate against the other live bound with the same `>=` error as the combined setter (`FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound`). Combined setter remains the way to move both bounds when the new pair would fail a one-sided check.
+
+- [ ] **R5:** Same math, fewer SLOADs in batch:
+
+  ```solidity
+  function _calculateFee(uint256 purchaseAmount) internal view returns (uint256) {
+      return _calculateFeeWithParams(purchaseAmount, _feeSettings());
+  }
+
+  function _calculateFeeWithParams(uint256 purchaseAmount, FeeSettings memory feeSettings)
+      internal
+      pure
+      returns (uint256);
+
+  function _feeSettings() internal view returns (FeeSettings memory);
+  ```
+
+  `_calculateFeeAndNetAmounts` loads `FeeSettings` once before the loop and calls `_calculateFeeWithParams`. Linear formula stays identical to today’s `_calculateFee`. Do not add `getFeeSettings()` on `IFeeHandler`.
+
+## Out of scope
+
+- [ ] Flatten to one rate, new purchase bounds, or a `maxFeeRate` cap.
+- [ ] `getFeeSettings()` on `IFeeHandler`.
+- [ ] Constructor validation of fee settings.
+- [ ] R18 packing, R19 pause, R12/R13/optionals (PR 2 / later PRs).
+- [ ] R6 / R17 purchase-path / `nonReentrant` work.
+- [ ] Event reshaping (R9); fee events keep today’s indexed uints.
+- [ ] Handler / accounting / SIP-0094 (R1, R20).
+- [ ] `forge fmt` of existing files.
+- [ ] Deploy broadcasts or live addresses.
+- [ ] `dca-out-contracts`.
+
+## Files likely touched
+
+- `src/FeeHandler.sol`
+- `test/ai-generated/unit/FeeHandlerTest.t.sol`
+- `test/mocks/FeeHandlerHarness.sol`
+- `docs/relaunch/README.md` (assignment status)
+
+`PurchaseMoc` / `PurchaseUniswap` keep calling `_calculateFee` / `_calculateFeeAndNetAmounts`; no change unless a compiler error forces it. Extra files belong in the PR write-up.
+
+## Required tests
+
+Commands (targeted first, then done-gate):
+
+```bash
+forge test --match-contract FeeHandlerTest
+SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus forge test --match-contract HandlerTestHarness
+make check
+```
+
+Behaviors to assert:
+
+- Existing fee unit tests (below lower bound, above upper bound, interpolated, at bounds) still pass for `_calculateFee`.
+- `minFeeRate == maxFeeRate` (flat) still charges `amount * minFeeRate / 10_000` regardless of purchase amount vs bounds.
+- `setFeeRateParams` that raises min above the old max but below the new max (e.g. 100/200 → 250/400) succeeds and stores the new pair.
+- `setFeeRateParams` that moves both bounds so the new lower is `>=` the old upper (e.g. 100/1000 ether → 2000/5000 ether) succeeds.
+- Invalid combined pairs still revert (`min > max`, `lower >= upper`).
+- `setPurchaseLowerBound` with `lower >=` current upper reverts; `setPurchaseUpperBound` with `upper <=` current lower reverts.
+- One-sided bound updates that stay strictly inside the other live bound still succeed.
+- `_calculateFeeAndNetAmounts` does not call a `view` helper that re-reads fee storage inside the loop (reviewer: inspect the loop).
+- Batch of N purchases produces the same per-item fees (and nets) as N sequential `_calculateFee` calls with the same amounts.
+
+Fork tests: not required.
+
+## Success criteria
+
+- [ ] Raising the min/max band in one `setFeeRateParams` call succeeds when the new pair is valid.
+- [ ] Individual bound setters cannot store `lower >= upper`; combined setter still moves both.
+- [ ] Batch fee math matches sequential `_calculateFee`; four fee SLOADs happen once per `_calculateFeeAndNetAmounts` call, not per item.
+- [ ] Interpolation and flat (`min == max`) results are unchanged.
+- [ ] Targeted tests above pass; `make check` passes.
+- [ ] Protocol invariants in `AGENTS.md` unchanged.
+
+## Reviewer checklist
+
+- [ ] Matches **Scope**; nothing from **Out of scope**.
+- [ ] Protocol invariants in `AGENTS.md` still hold (this spec does not change them).
+- [ ] Tests in the PR match **Required tests**.
+- [ ] Files beyond this list are limited to direct dependencies / failing-test fallout and are named in the PR.
+- [ ] No unrelated refactors; history is reviewable.
+- [ ] `_calculateFeeAndNetAmounts` loop uses `_calculateFeeWithParams` with a once-loaded `FeeSettings`, not `_calculateFee`.
+
+## ABI / deploy / cutover impact
+
+- ABI: none. Setter signatures and events unchanged. Individual bound setters revert in more cases (`FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound`). No `getFeeSettings`.
+- Scripts: none. Production can keep `minFeeRate == maxFeeRate == 100` (flat 1%).
+- Cutover: none. Owner can now raise the fee band in one `setFeeRateParams` call. Do not include broadcast steps.

--- a/docs/relaunch/R3-fee-handling.md
+++ b/docs/relaunch/R3-fee-handling.md
@@ -4,13 +4,13 @@ Status: **in progress** (GitHub #46) · Assigned: yes · Optional/further-review
 
 ## Objective
 
-Keep the linear fee model. Make `setFeeRateParams` able to raise the rate band in one call, keep purchase-bound invariants on the individual setters and constructor, and load fee storage once per batch so interpolation math does not re-SLOAD on every purchase.
+Keep the linear fee model. Make `setFeeRateParams` able to raise the rate band in one call, keep purchase-bound and rate-cap invariants on the individual setters and constructor, reject a zero fee collector, expose `getFeeSettings`, and load fee storage once per batch so interpolation math does not re-SLOAD on every purchase.
 
 ## Background
 
 PR 5 bundles R3, R4, and R5 because they are isolated `FeeHandler` work and all apply only if the linear model stays. Product gate (this chat): **keep linear**. Do not flatten to one rate.
 
-Linear means: `maxFeeRate` at or below `feePurchaseLowerBound`, `minFeeRate` at or above `feePurchaseUpperBound`, straight interpolation in between. Equal min and max is a valid flat rate (production is 100/100). There is no on-chain cap on `maxFeeRate`; do not add one.
+Linear means: `maxFeeRate` at or below `feePurchaseLowerBound`, `minFeeRate` at or above `feePurchaseUpperBound`, straight interpolation in between. Equal min and max is a valid flat rate (production is 100/100).
 
 **R3:** `setFeeRateParams` validates `newMin ≤ newMax`, then calls `setMinFeeRate` first. That setter compares against the **live** `s_maxFeeRate`, not the new max. Raising the band in one call (e.g. 100/200 → 250/400) reverts even though the new pair is valid. Individual min/max setters already keep `min ≤ max` against the other live rate (`f07c57b` / `eaca027`). Combined bound check is already `>=`.
 
@@ -18,13 +18,13 @@ Linear means: `maxFeeRate` at or below `feePurchaseLowerBound`, `minFeeRate` at 
 
 **R5:** `_calculateFeeAndNetAmounts` calls `_calculateFee` per item. `_calculateFee` is `view` and SLOAD’s the four fee fields on every iteration. Those values do not change during the tx.
 
-**Constructor hardening:** User-requested after review. Constructor fee settings should satisfy the same `min <= max` and `lower < upper` invariants as owner updates, so a handler cannot be born with fee settings that later setters would reject.
+**Constructor / collector / cap / getter (user-requested on this PR):** There is no later relaunch PR that owns fee-collector safety, an on-chain `maxFeeRate` ceiling, or `getFeeSettings`. Apply the same pair checks at construction; reject `feeCollector == address(0)` in the constructor and `setFeeCollectorAddress`; cap `maxFeeRate` at 5% (`500` with `FEE_PERCENTAGE_DIVISOR = 10_000`); expose `getFeeSettings()` wrapping `_feeSettings()`.
 
-`PurchaseMoc` / `PurchaseUniswap` keep calling `_calculateFee` / `_calculateFeeAndNetAmounts`. Do not change fee rates, interpolation, or which path (`buyRbtc` vs batch) is used.
+`PurchaseMoc` / `PurchaseUniswap` keep calling `_calculateFee` / `_calculateFeeAndNetAmounts`. Do not change fee rates, interpolation, or which path (`buyRbtc` vs batch) is used beyond the SLOAD load-once change.
 
 ## Open product decisions
 
-**none** — keep linear (answered this chat). Flatten is out of scope.
+**none** — keep linear (answered this chat). Flatten is out of scope. Cap chosen at 5% (`MAX_FEE_RATE_CAP = 500`) this chat.
 
 ## Scope
 
@@ -47,14 +47,17 @@ Linear means: `maxFeeRate` at or below `feePurchaseLowerBound`, `minFeeRate` at 
   function _feeSettings() internal view returns (FeeSettings memory);
   ```
 
-  `_calculateFeeAndNetAmounts` loads `FeeSettings` once before the loop and calls `_calculateFeeWithParams`. Linear formula stays identical to today’s `_calculateFee`. Do not add `getFeeSettings()` on `IFeeHandler`.
+  `_calculateFeeAndNetAmounts` loads `FeeSettings` once before the loop and calls `_calculateFeeWithParams`. Linear formula stays identical to today’s `_calculateFee`. Expose `getFeeSettings()` on `IFeeHandler` as an external wrapper for `_feeSettings()`.
 
-- [x] Constructor validation: reject invalid initial fee settings with the same errors as `setFeeRateParams` (`minFeeRate > maxFeeRate`, `feePurchaseLowerBound >= feePurchaseUpperBound`). Do not add a `maxFeeRate` cap.
+- [x] Constructor validation: reject invalid initial fee settings with the same errors as `setFeeRateParams` (`minFeeRate > maxFeeRate`, `feePurchaseLowerBound >= feePurchaseUpperBound`, `maxFeeRate > MAX_FEE_RATE_CAP`).
+
+- [x] Zero fee collector: revert `FeeHandler__InvalidFeeCollector` in the constructor and `setFeeCollectorAddress` when `feeCollector == address(0)`.
+
+- [x] `maxFeeRate` cap: `MAX_FEE_RATE_CAP = 500` (5%). Enforce in `_validateFeeSettings` (constructor + `setFeeRateParams`) and in `setMaxFeeRate`. Do not invent a separate min-rate cap; `min ≤ max` plus the max cap is enough.
 
 ## Out of scope
 
-- [ ] Flatten to one rate, new purchase bounds, or a `maxFeeRate` cap.
-- [ ] `getFeeSettings()` on `IFeeHandler`.
+- [ ] Flatten to one rate or new purchase-bound product values.
 - [ ] R18 packing, R19 pause, R12/R13/optionals (PR 2 / later PRs).
 - [ ] R6 / R17 purchase-path / `nonReentrant` work.
 - [ ] Event reshaping (R9); fee events keep today’s indexed uints.
@@ -66,6 +69,7 @@ Linear means: `maxFeeRate` at or below `feePurchaseLowerBound`, `minFeeRate` at 
 ## Files likely touched
 
 - `src/FeeHandler.sol`
+- `src/interfaces/IFeeHandler.sol`
 - `test/ai-generated/unit/FeeHandlerTest.t.sol`
 - `test/mocks/FeeHandlerHarness.sol`
 - `docs/relaunch/README.md` (assignment status)
@@ -89,7 +93,10 @@ Behaviors to assert:
 - `setFeeRateParams` that raises min above the old max but below the new max (e.g. 100/200 → 250/400) succeeds and stores the new pair.
 - `setFeeRateParams` that moves both bounds so the new lower is `>=` the old upper (e.g. 100/1000 ether → 2000/5000 ether) succeeds.
 - Invalid combined pairs still revert (`min > max`, `lower >= upper`).
-- Constructor settings with `min > max` or `lower >= upper` revert with the same errors as the combined setter.
+- Constructor settings with `min > max`, `lower >= upper`, `maxFeeRate > MAX_FEE_RATE_CAP`, or zero collector revert.
+- `setMaxFeeRate` / `setFeeRateParams` revert when `maxFeeRate > MAX_FEE_RATE_CAP`; `maxFeeRate == MAX_FEE_RATE_CAP` succeeds.
+- `setFeeCollectorAddress(address(0))` reverts; non-zero succeeds.
+- `getFeeSettings()` matches the four individual getters.
 - `setPurchaseLowerBound` with `lower >=` current upper reverts; `setPurchaseUpperBound` with `upper <=` current lower reverts.
 - One-sided bound updates that stay strictly inside the other live bound still succeed.
 - `_calculateFeeAndNetAmounts` does not call a `view` helper that re-reads fee storage inside the loop (reviewer: inspect the loop).
@@ -102,7 +109,9 @@ Fork tests: not required.
 - [x] Raising the min/max band in one `setFeeRateParams` call succeeds when the new pair is valid.
 - [x] Individual bound setters cannot store `lower >= upper`; combined setter still moves both.
 - [x] Batch fee math matches sequential `_calculateFee`; four fee SLOADs happen once per `_calculateFeeAndNetAmounts` call, not per item.
-- [x] Constructor cannot deploy a handler with invalid fee settings.
+- [x] Constructor cannot deploy a handler with invalid fee settings or a zero collector.
+- [x] `maxFeeRate` cannot exceed `MAX_FEE_RATE_CAP` (5%) via constructor, combined setter, or `setMaxFeeRate`.
+- [x] `getFeeSettings()` returns the same four fields as the individual getters.
 - [x] Interpolation and flat (`min == max`) results are unchanged.
 - [x] Targeted tests above pass; `make check` passes.
 - [x] Protocol invariants in `AGENTS.md` unchanged.
@@ -118,6 +127,6 @@ Fork tests: not required.
 
 ## ABI / deploy / cutover impact
 
-- ABI: none. Setter signatures and events unchanged. Individual bound setters revert in more cases (`FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound`). No `getFeeSettings`.
-- Scripts: none. Production can keep `minFeeRate == maxFeeRate == 100` (flat 1%).
-- Cutover: none. Owner can now raise the fee band in one `setFeeRateParams` call. Do not include broadcast steps.
+- ABI: add `getFeeSettings() view returns (FeeSettings)`; add errors `FeeHandler__InvalidFeeCollector` and `FeeHandler__MaxFeeRateExceedsCap`; add public constant getter `MAX_FEE_RATE_CAP()`. Individual bound setters revert in more cases (`FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound`). `setMaxFeeRate` / `setFeeRateParams` / constructor reject `maxFeeRate > 500`. `setFeeCollectorAddress` and constructor reject `address(0)`.
+- Scripts: none required. Production can keep `minFeeRate == maxFeeRate == 100` (flat 1%), well under the 5% cap.
+- Cutover: owner can raise the fee band in one `setFeeRateParams` call, but never above 5%. Frontends/indexers may read all fee params via `getFeeSettings()`. Do not include broadcast steps.

--- a/docs/relaunch/R3-fee-handling.md
+++ b/docs/relaunch/R3-fee-handling.md
@@ -4,7 +4,7 @@ Status: **in progress** (GitHub #46) · Assigned: yes · Optional/further-review
 
 ## Objective
 
-Keep the linear fee model. Make `setFeeRateParams` able to raise the rate band in one call, keep purchase-bound invariants on the individual setters, and load fee storage once per batch so interpolation math does not re-SLOAD on every purchase.
+Keep the linear fee model. Make `setFeeRateParams` able to raise the rate band in one call, keep purchase-bound invariants on the individual setters and constructor, and load fee storage once per batch so interpolation math does not re-SLOAD on every purchase.
 
 ## Background
 
@@ -17,6 +17,8 @@ Linear means: `maxFeeRate` at or below `feePurchaseLowerBound`, `minFeeRate` at 
 **R4:** Combined setter requires `lower < upper`, but `setPurchaseLowerBound` / `setPurchaseUpperBound` still write without comparing to the other live bound, so `lower ≥ upper` can be stored.
 
 **R5:** `_calculateFeeAndNetAmounts` calls `_calculateFee` per item. `_calculateFee` is `view` and SLOAD’s the four fee fields on every iteration. Those values do not change during the tx.
+
+**Constructor hardening:** User-requested after review. Constructor fee settings should satisfy the same `min <= max` and `lower < upper` invariants as owner updates, so a handler cannot be born with fee settings that later setters would reject.
 
 `PurchaseMoc` / `PurchaseUniswap` keep calling `_calculateFee` / `_calculateFeeAndNetAmounts`. Do not change fee rates, interpolation, or which path (`buyRbtc` vs batch) is used.
 
@@ -47,11 +49,12 @@ Linear means: `maxFeeRate` at or below `feePurchaseLowerBound`, `minFeeRate` at 
 
   `_calculateFeeAndNetAmounts` loads `FeeSettings` once before the loop and calls `_calculateFeeWithParams`. Linear formula stays identical to today’s `_calculateFee`. Do not add `getFeeSettings()` on `IFeeHandler`.
 
+- [x] Constructor validation: reject invalid initial fee settings with the same errors as `setFeeRateParams` (`minFeeRate > maxFeeRate`, `feePurchaseLowerBound >= feePurchaseUpperBound`). Do not add a `maxFeeRate` cap.
+
 ## Out of scope
 
 - [ ] Flatten to one rate, new purchase bounds, or a `maxFeeRate` cap.
 - [ ] `getFeeSettings()` on `IFeeHandler`.
-- [ ] Constructor validation of fee settings.
 - [ ] R18 packing, R19 pause, R12/R13/optionals (PR 2 / later PRs).
 - [ ] R6 / R17 purchase-path / `nonReentrant` work.
 - [ ] Event reshaping (R9); fee events keep today’s indexed uints.
@@ -86,6 +89,7 @@ Behaviors to assert:
 - `setFeeRateParams` that raises min above the old max but below the new max (e.g. 100/200 → 250/400) succeeds and stores the new pair.
 - `setFeeRateParams` that moves both bounds so the new lower is `>=` the old upper (e.g. 100/1000 ether → 2000/5000 ether) succeeds.
 - Invalid combined pairs still revert (`min > max`, `lower >= upper`).
+- Constructor settings with `min > max` or `lower >= upper` revert with the same errors as the combined setter.
 - `setPurchaseLowerBound` with `lower >=` current upper reverts; `setPurchaseUpperBound` with `upper <=` current lower reverts.
 - One-sided bound updates that stay strictly inside the other live bound still succeed.
 - `_calculateFeeAndNetAmounts` does not call a `view` helper that re-reads fee storage inside the loop (reviewer: inspect the loop).
@@ -98,6 +102,7 @@ Fork tests: not required.
 - [x] Raising the min/max band in one `setFeeRateParams` call succeeds when the new pair is valid.
 - [x] Individual bound setters cannot store `lower >= upper`; combined setter still moves both.
 - [x] Batch fee math matches sequential `_calculateFee`; four fee SLOADs happen once per `_calculateFeeAndNetAmounts` call, not per item.
+- [x] Constructor cannot deploy a handler with invalid fee settings.
 - [x] Interpolation and flat (`min == max`) results are unchanged.
 - [x] Targeted tests above pass; `make check` passes.
 - [x] Protocol invariants in `AGENTS.md` unchanged.

--- a/docs/relaunch/R3-fee-handling.md
+++ b/docs/relaunch/R3-fee-handling.md
@@ -26,11 +26,11 @@ Linear means: `maxFeeRate` at or below `feePurchaseLowerBound`, `minFeeRate` at 
 
 ## Scope
 
-- [ ] **R3:** After validating the new pair, write rates and bounds in `setFeeRateParams` instead of routing through the individual setters. Keep the existing pair checks (`minFeeRate > maxFeeRate`, `feePurchaseLowerBound >= feePurchaseUpperBound`). Only write/emit a field when it changes (same as today’s `if (s_* != new)`). Individual setters stay for one-sided updates.
+- [x] **R3:** After validating the new pair, write rates and bounds in `setFeeRateParams` instead of routing through the individual setters. Keep the existing pair checks (`minFeeRate > maxFeeRate`, `feePurchaseLowerBound >= feePurchaseUpperBound`). Only write/emit a field when it changes (same as today’s `if (s_* != new)`). Individual setters stay for one-sided updates.
 
-- [ ] **R4:** On `setPurchaseLowerBound` / `setPurchaseUpperBound`, validate against the other live bound with the same `>=` error as the combined setter (`FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound`). Combined setter remains the way to move both bounds when the new pair would fail a one-sided check.
+- [x] **R4:** On `setPurchaseLowerBound` / `setPurchaseUpperBound`, validate against the other live bound with the same `>=` error as the combined setter (`FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound`). Combined setter remains the way to move both bounds when the new pair would fail a one-sided check.
 
-- [ ] **R5:** Same math, fewer SLOADs in batch:
+- [x] **R5:** Same math, fewer SLOADs in batch:
 
   ```solidity
   function _calculateFee(uint256 purchaseAmount) internal view returns (uint256) {
@@ -75,7 +75,7 @@ Commands (targeted first, then done-gate):
 
 ```bash
 forge test --match-contract FeeHandlerTest
-SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus forge test --match-contract HandlerTestHarness
+SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus forge test --match-contract TropykusErc20HandlerTest --match-test modifyFeeSettings
 make check
 ```
 
@@ -95,12 +95,12 @@ Fork tests: not required.
 
 ## Success criteria
 
-- [ ] Raising the min/max band in one `setFeeRateParams` call succeeds when the new pair is valid.
-- [ ] Individual bound setters cannot store `lower >= upper`; combined setter still moves both.
-- [ ] Batch fee math matches sequential `_calculateFee`; four fee SLOADs happen once per `_calculateFeeAndNetAmounts` call, not per item.
-- [ ] Interpolation and flat (`min == max`) results are unchanged.
-- [ ] Targeted tests above pass; `make check` passes.
-- [ ] Protocol invariants in `AGENTS.md` unchanged.
+- [x] Raising the min/max band in one `setFeeRateParams` call succeeds when the new pair is valid.
+- [x] Individual bound setters cannot store `lower >= upper`; combined setter still moves both.
+- [x] Batch fee math matches sequential `_calculateFee`; four fee SLOADs happen once per `_calculateFeeAndNetAmounts` call, not per item.
+- [x] Interpolation and flat (`min == max`) results are unchanged.
+- [x] Targeted tests above pass; `make check` passes.
+- [x] Protocol invariants in `AGENTS.md` unchanged.
 
 ## Reviewer checklist
 

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -23,4 +23,5 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 - Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub [#42](https://github.com/BitChillRSK/dca-contracts/pull/42)). Rootstock testnet accepted solc 0.8.36 / `cancun`.
 - Assigned: [R2-utc-purchase-period.md](./R2-utc-purchase-period.md) (PR 3, GitHub [#44](https://github.com/BitChillRSK/dca-contracts/pull/44)). No product gates. Does not wait on PR 2.
 - Assigned: [R7-dca-manager-small-fixes.md](./R7-dca-manager-small-fixes.md) (PR 4, GitHub [#45](https://github.com/BitChillRSK/dca-contracts/pull/45)). Bundles R7 / R11 / R14. No product gates. Stacked on [#44](https://github.com/BitChillRSK/dca-contracts/pull/44).
-- Next unassigned: `Start with R3` (PR 5, fee handling: R3 / R4 / R5). Ask fee model if PR 2 did not record it. PR 2 (decision record) stays available when the human wants to record fee / R18 / R19.
+- Assigned: [R3-fee-handling.md](./R3-fee-handling.md) (PR 5). Bundles R3 / R4 / R5. Keep linear (gate answered this chat). Stacked on [#45](https://github.com/BitChillRSK/dca-contracts/pull/45).
+- Next unassigned: `Start with R6` (PR 6, hot-path cleanup: R6 / R17). No product gates. PR 2 (decision record) stays available when the human wants to record R18 / R19 / optionals.

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -23,5 +23,5 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 - Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub [#42](https://github.com/BitChillRSK/dca-contracts/pull/42)). Rootstock testnet accepted solc 0.8.36 / `cancun`.
 - Assigned: [R2-utc-purchase-period.md](./R2-utc-purchase-period.md) (PR 3, GitHub [#44](https://github.com/BitChillRSK/dca-contracts/pull/44)). No product gates. Does not wait on PR 2.
 - Assigned: [R7-dca-manager-small-fixes.md](./R7-dca-manager-small-fixes.md) (PR 4, GitHub [#45](https://github.com/BitChillRSK/dca-contracts/pull/45)). Bundles R7 / R11 / R14. No product gates. Stacked on [#44](https://github.com/BitChillRSK/dca-contracts/pull/44).
-- Assigned: [R3-fee-handling.md](./R3-fee-handling.md) (PR 5). Bundles R3 / R4 / R5. Keep linear (gate answered this chat). Stacked on [#45](https://github.com/BitChillRSK/dca-contracts/pull/45).
+- Assigned: [R3-fee-handling.md](./R3-fee-handling.md) (PR 5, GitHub [#46](https://github.com/BitChillRSK/dca-contracts/pull/46)). Bundles R3 / R4 / R5. Keep linear (gate answered this chat). Stacked on [#45](https://github.com/BitChillRSK/dca-contracts/pull/45).
 - Next unassigned: `Start with R6` (PR 6, hot-path cleanup: R6 / R17). No product gates. PR 2 (decision record) stays available when the human wants to record R18 / R19 / optionals.

--- a/src/FeeHandler.sol
+++ b/src/FeeHandler.sol
@@ -23,8 +23,11 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
     uint256 internal s_feePurchaseUpperBound; // Spending above upper bound gets the minimum fee rate
     address internal s_feeCollector; // Address to which the fees charged to the user will be sent
     uint256 constant FEE_PERCENTAGE_DIVISOR = 10_000; // feeRate will belong to [100, 200], so we need to divide by 10,000 (100 * 100)
+    /// @notice Hard ceiling on fee rates (5%). Owner cannot set max (or a flat min==max) above this.
+    uint256 public constant MAX_FEE_RATE_CAP = 500;
 
     constructor(address feeCollector, FeeSettings memory feeSettings) Ownable() {
+        if (feeCollector == address(0)) revert FeeHandler__InvalidFeeCollector();
         _validateFeeSettings(
             feeSettings.minFeeRate,
             feeSettings.maxFeeRate,
@@ -90,6 +93,7 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
      * @param maxFeeRate: the maximum fee rate
      */
     function setMaxFeeRate(uint256 maxFeeRate) public override onlyOwner {
+        if (maxFeeRate > MAX_FEE_RATE_CAP) revert FeeHandler__MaxFeeRateExceedsCap();
         if (maxFeeRate < s_minFeeRate) revert FeeHandler__MinFeeRateCannotBeHigherThanMax();
         s_maxFeeRate = maxFeeRate;
         emit FeeHandler__MaxFeeRateSet(maxFeeRate);
@@ -124,6 +128,7 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
      * @param feeCollector: the fee collector address
      */
     function setFeeCollectorAddress(address feeCollector) external override onlyOwner {
+        if (feeCollector == address(0)) revert FeeHandler__InvalidFeeCollector();
         s_feeCollector = feeCollector;
         emit FeeHandler__FeeCollectorAddressSet(feeCollector);
     }
@@ -170,6 +175,13 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
         return s_feeCollector;
     }
 
+    /**
+     * @notice get the fee settings used for purchase fee calculation
+     */
+    function getFeeSettings() external view override returns (FeeSettings memory) {
+        return _feeSettings();
+    }
+
     /*//////////////////////////////////////////////////////////////
                            INTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////*/
@@ -180,6 +192,7 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
         uint256 feePurchaseLowerBound,
         uint256 feePurchaseUpperBound
     ) private pure {
+        if (maxFeeRate > MAX_FEE_RATE_CAP) revert FeeHandler__MaxFeeRateExceedsCap();
         if (minFeeRate > maxFeeRate) revert FeeHandler__MinFeeRateCannotBeHigherThanMax();
         if (feePurchaseLowerBound >= feePurchaseUpperBound) revert FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound();
     }

--- a/src/FeeHandler.sol
+++ b/src/FeeHandler.sol
@@ -25,6 +25,13 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
     uint256 constant FEE_PERCENTAGE_DIVISOR = 10_000; // feeRate will belong to [100, 200], so we need to divide by 10,000 (100 * 100)
 
     constructor(address feeCollector, FeeSettings memory feeSettings) Ownable() {
+        _validateFeeSettings(
+            feeSettings.minFeeRate,
+            feeSettings.maxFeeRate,
+            feeSettings.feePurchaseLowerBound,
+            feeSettings.feePurchaseUpperBound
+        );
+
         s_feeCollector = feeCollector;
         s_minFeeRate = feeSettings.minFeeRate;
         s_maxFeeRate = feeSettings.maxFeeRate;
@@ -48,9 +55,7 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
         override
         onlyOwner
     {
-        // Validate parameters
-        if (minFeeRate > maxFeeRate) revert FeeHandler__MinFeeRateCannotBeHigherThanMax();
-        if (feePurchaseLowerBound >= feePurchaseUpperBound) revert FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound();
+        _validateFeeSettings(minFeeRate, maxFeeRate, feePurchaseLowerBound, feePurchaseUpperBound);
 
         if (s_minFeeRate != minFeeRate) {
             s_minFeeRate = minFeeRate;
@@ -168,6 +173,16 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
     /*//////////////////////////////////////////////////////////////
                            INTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////*/
+
+    function _validateFeeSettings(
+        uint256 minFeeRate,
+        uint256 maxFeeRate,
+        uint256 feePurchaseLowerBound,
+        uint256 feePurchaseUpperBound
+    ) private pure {
+        if (minFeeRate > maxFeeRate) revert FeeHandler__MinFeeRateCannotBeHigherThanMax();
+        if (feePurchaseLowerBound >= feePurchaseUpperBound) revert FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound();
+    }
 
     /**
      * @dev Calculates the fee based on the purchase amount.

--- a/src/FeeHandler.sol
+++ b/src/FeeHandler.sol
@@ -52,10 +52,22 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
         if (minFeeRate > maxFeeRate) revert FeeHandler__MinFeeRateCannotBeHigherThanMax();
         if (feePurchaseLowerBound >= feePurchaseUpperBound) revert FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound();
 
-        if (s_minFeeRate != minFeeRate) setMinFeeRate(minFeeRate);
-        if (s_maxFeeRate != maxFeeRate) setMaxFeeRate(maxFeeRate);
-        if (s_feePurchaseLowerBound != feePurchaseLowerBound) setPurchaseLowerBound(feePurchaseLowerBound);
-        if (s_feePurchaseUpperBound != feePurchaseUpperBound) setPurchaseUpperBound(feePurchaseUpperBound);
+        if (s_minFeeRate != minFeeRate) {
+            s_minFeeRate = minFeeRate;
+            emit FeeHandler__MinFeeRateSet(minFeeRate);
+        }
+        if (s_maxFeeRate != maxFeeRate) {
+            s_maxFeeRate = maxFeeRate;
+            emit FeeHandler__MaxFeeRateSet(maxFeeRate);
+        }
+        if (s_feePurchaseLowerBound != feePurchaseLowerBound) {
+            s_feePurchaseLowerBound = feePurchaseLowerBound;
+            emit FeeHandler__PurchaseLowerBoundSet(feePurchaseLowerBound);
+        }
+        if (s_feePurchaseUpperBound != feePurchaseUpperBound) {
+            s_feePurchaseUpperBound = feePurchaseUpperBound;
+            emit FeeHandler__PurchaseUpperBoundSet(feePurchaseUpperBound);
+        }
     }
 
     /**
@@ -83,6 +95,9 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
      * @param feePurchaseLowerBound: the purchase lower bound
      */
     function setPurchaseLowerBound(uint256 feePurchaseLowerBound) public override onlyOwner {
+        if (feePurchaseLowerBound >= s_feePurchaseUpperBound) {
+            revert FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound();
+        }
         s_feePurchaseLowerBound = feePurchaseLowerBound;
         emit FeeHandler__PurchaseLowerBoundSet(feePurchaseLowerBound);
     }
@@ -92,6 +107,9 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
      * @param feePurchaseUpperBound: the purchase upper bound
      */
     function setPurchaseUpperBound(uint256 feePurchaseUpperBound) public override onlyOwner {
+        if (s_feePurchaseLowerBound >= feePurchaseUpperBound) {
+            revert FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound();
+        }
         s_feePurchaseUpperBound = feePurchaseUpperBound;
         emit FeeHandler__PurchaseUpperBoundSet(feePurchaseUpperBound);
     }
@@ -157,10 +175,60 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
      * @return The fee amount to be deducted from the purchase amount.
      */
     function _calculateFee(uint256 purchaseAmount) internal view returns (uint256) {
-        uint256 minFeeRate = s_minFeeRate;
-        uint256 maxFeeRate = s_maxFeeRate;
-        uint256 feePurchaseLowerBound = s_feePurchaseLowerBound;
-        uint256 feePurchaseUpperBound = s_feePurchaseUpperBound;
+        return _calculateFeeWithParams(purchaseAmount, _feeSettings());
+    }
+
+    /**
+     * @notice Calculate the fee and net amounts for a batch of purchase amounts.
+     * @param purchaseAmounts The array with the raw purchase amounts specified by users.
+     * @return aggregatedFee      The total fee to be collected for all purchases.
+     * @return netAmountsToSpend  An array with the net amounts (purchase amount minus fee) for each user.
+     * @return totalAmountToSpend The aggregated net amount that will actually be used to buy rBTC.
+     */
+    function _calculateFeeAndNetAmounts(uint256[] memory purchaseAmounts)
+        internal
+        view
+        returns (uint256 aggregatedFee, uint256[] memory netAmountsToSpend, uint256 totalAmountToSpend)
+    {
+        uint256 len = purchaseAmounts.length;
+        netAmountsToSpend = new uint256[](len);
+        FeeSettings memory feeSettings = _feeSettings();
+
+        for (uint256 i; i < len; ++i) {
+            uint256 amount = purchaseAmounts[i];
+            uint256 fee = _calculateFeeWithParams(amount, feeSettings);
+            aggregatedFee += fee;
+
+            uint256 net = amount - fee;
+            netAmountsToSpend[i] = net;
+            totalAmountToSpend += net;
+        }
+    }
+
+    /**
+     * @dev Pack the four fee storage fields for a single load per batch.
+     */
+    function _feeSettings() internal view returns (FeeSettings memory) {
+        return FeeSettings({
+            minFeeRate: s_minFeeRate,
+            maxFeeRate: s_maxFeeRate,
+            feePurchaseLowerBound: s_feePurchaseLowerBound,
+            feePurchaseUpperBound: s_feePurchaseUpperBound
+        });
+    }
+
+    /**
+     * @dev Same interpolation as `_calculateFee`, using already-loaded fee settings.
+     */
+    function _calculateFeeWithParams(uint256 purchaseAmount, FeeSettings memory feeSettings)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 minFeeRate = feeSettings.minFeeRate;
+        uint256 maxFeeRate = feeSettings.maxFeeRate;
+        uint256 feePurchaseLowerBound = feeSettings.feePurchaseLowerBound;
+        uint256 feePurchaseUpperBound = feeSettings.feePurchaseUpperBound;
 
         if (minFeeRate == maxFeeRate || purchaseAmount >= feePurchaseUpperBound) {
             return purchaseAmount * minFeeRate / FEE_PERCENTAGE_DIVISOR;
@@ -178,32 +246,6 @@ abstract contract FeeHandler is IFeeHandler, Ownable {
                     / (feePurchaseUpperBound - feePurchaseLowerBound);
         }
         return purchaseAmount * feeRate / FEE_PERCENTAGE_DIVISOR;
-    }
-
-    /**
-     * @notice Calculate the fee and net amounts for a batch of purchase amounts.
-     * @param purchaseAmounts The array with the raw purchase amounts specified by users.
-     * @return aggregatedFee      The total fee to be collected for all purchases.
-     * @return netAmountsToSpend  An array with the net amounts (purchase amount minus fee) for each user.
-     * @return totalAmountToSpend The aggregated net amount that will actually be used to buy rBTC.
-     */
-    function _calculateFeeAndNetAmounts(uint256[] memory purchaseAmounts)
-        internal
-        view
-        returns (uint256 aggregatedFee, uint256[] memory netAmountsToSpend, uint256 totalAmountToSpend)
-    {
-        uint256 len = purchaseAmounts.length;
-        netAmountsToSpend = new uint256[](len);
-        
-        for (uint256 i; i < len; ++i) {
-            uint256 amount = purchaseAmounts[i];
-            uint256 fee = _calculateFee(amount);
-            aggregatedFee += fee;
-
-            uint256 net = amount - fee;
-            netAmountsToSpend[i] = net;
-            totalAmountToSpend += net;
-        }
     }
 
     /**

--- a/src/interfaces/IFeeHandler.sol
+++ b/src/interfaces/IFeeHandler.sol
@@ -32,6 +32,8 @@ interface IFeeHandler {
 
     error FeeHandler__MinFeeRateCannotBeHigherThanMax();
     error FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound();
+    error FeeHandler__InvalidFeeCollector();
+    error FeeHandler__MaxFeeRateExceedsCap();
 
     ///////////////////////////////
     // External functions /////////
@@ -101,4 +103,9 @@ interface IFeeHandler {
      * @dev Gets the fee collector address
      */
     function getFeeCollectorAddress() external returns (address);
+
+    /**
+     * @dev Gets the four fee settings used for purchase fee calculation.
+     */
+    function getFeeSettings() external view returns (FeeSettings memory);
 }

--- a/test/ai-generated/unit/FeeHandlerTest.t.sol
+++ b/test/ai-generated/unit/FeeHandlerTest.t.sol
@@ -124,6 +124,79 @@ contract FeeHandlerTest is Test {
         assertEq(feeHandler.getFeePurchaseUpperBound(), newUpper, "Upper bound not set");
     }
 
+    function test_setFeeRateParams_raisesMinAboveOldMax() public {
+        uint256 newMin = 250;
+        uint256 newMax = 400;
+
+        feeHandler.setFeeRateParams(newMin, newMax, LOWER_BOUND, UPPER_BOUND);
+
+        assertEq(feeHandler.getMinFeeRate(), newMin);
+        assertEq(feeHandler.getMaxFeeRate(), newMax);
+        assertEq(feeHandler.getFeePurchaseLowerBound(), LOWER_BOUND);
+        assertEq(feeHandler.getFeePurchaseUpperBound(), UPPER_BOUND);
+    }
+
+    function test_setFeeRateParams_raisesBothBoundsAboveOldUpper() public {
+        uint256 newLower = 2000 ether;
+        uint256 newUpper = 5000 ether;
+
+        feeHandler.setFeeRateParams(MIN_FEE_RATE, MAX_FEE_RATE, newLower, newUpper);
+
+        assertEq(feeHandler.getFeePurchaseLowerBound(), newLower);
+        assertEq(feeHandler.getFeePurchaseUpperBound(), newUpper);
+    }
+
+    function test_setPurchaseLowerBound_reverts_whenGteUpper() public {
+        vm.expectRevert(IFeeHandler.FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound.selector);
+        feeHandler.setPurchaseLowerBound(UPPER_BOUND);
+
+        vm.expectRevert(IFeeHandler.FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound.selector);
+        feeHandler.setPurchaseLowerBound(UPPER_BOUND + 1);
+    }
+
+    function test_setPurchaseUpperBound_reverts_whenLteLower() public {
+        vm.expectRevert(IFeeHandler.FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound.selector);
+        feeHandler.setPurchaseUpperBound(LOWER_BOUND);
+
+        vm.expectRevert(IFeeHandler.FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound.selector);
+        feeHandler.setPurchaseUpperBound(LOWER_BOUND - 1);
+    }
+
+    function test_calculateFee_flatMinEqualsMax() public {
+        uint256 flatRate = 100;
+        feeHandler.testSetMinFeeRate(flatRate);
+        feeHandler.testSetMaxFeeRate(flatRate);
+
+        uint256 below = 50 ether;
+        uint256 mid = 550 ether;
+        uint256 above = 2000 ether;
+        assertEq(feeHandler.exposedCalculateFee(below), below * flatRate / 10_000);
+        assertEq(feeHandler.exposedCalculateFee(mid), mid * flatRate / 10_000);
+        assertEq(feeHandler.exposedCalculateFee(above), above * flatRate / 10_000);
+    }
+
+    function test_calculateFeeAndNetAmounts_matchesSequentialCalculateFee() public {
+        uint256[] memory amounts = new uint256[](4);
+        amounts[0] = 50 ether;
+        amounts[1] = LOWER_BOUND;
+        amounts[2] = 550 ether;
+        amounts[3] = 2000 ether;
+
+        (uint256 aggregatedFee, uint256[] memory netAmounts, uint256 totalNet) =
+            feeHandler.exposedCalculateFeeAndNetAmounts(amounts);
+
+        uint256 expectedAggregatedFee;
+        uint256 expectedTotalNet;
+        for (uint256 i; i < amounts.length; ++i) {
+            uint256 expectedFee = feeHandler.exposedCalculateFee(amounts[i]);
+            expectedAggregatedFee += expectedFee;
+            expectedTotalNet += amounts[i] - expectedFee;
+            assertEq(netAmounts[i], amounts[i] - expectedFee);
+        }
+        assertEq(aggregatedFee, expectedAggregatedFee);
+        assertEq(totalNet, expectedTotalNet);
+    }
+
     // Test to ensure monotonicity: higher purchase amounts should have lower or equal fee rates
     function test_feeMonotonicity() public {
         uint256[] memory amounts = new uint256[](5);

--- a/test/ai-generated/unit/FeeHandlerTest.t.sol
+++ b/test/ai-generated/unit/FeeHandlerTest.t.sol
@@ -30,6 +30,30 @@ contract FeeHandlerTest is Test {
         feeHandler = new FeeHandlerHarness(settings);
     }
 
+    function test_constructor_reverts_invalidRates() public {
+        IFeeHandler.FeeSettings memory settings = IFeeHandler.FeeSettings({
+            minFeeRate: 300,
+            maxFeeRate: 200,
+            feePurchaseLowerBound: LOWER_BOUND,
+            feePurchaseUpperBound: UPPER_BOUND
+        });
+
+        vm.expectRevert(IFeeHandler.FeeHandler__MinFeeRateCannotBeHigherThanMax.selector);
+        new FeeHandlerHarness(settings);
+    }
+
+    function test_constructor_reverts_invalidBounds() public {
+        IFeeHandler.FeeSettings memory settings = IFeeHandler.FeeSettings({
+            minFeeRate: MIN_FEE_RATE,
+            maxFeeRate: MAX_FEE_RATE,
+            feePurchaseLowerBound: UPPER_BOUND,
+            feePurchaseUpperBound: LOWER_BOUND
+        });
+
+        vm.expectRevert(IFeeHandler.FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound.selector);
+        new FeeHandlerHarness(settings);
+    }
+
     function test_calculateFee_belowLowerBound() public {
         uint256 purchaseAmount = 50 ether; // below lower bound
         uint256 expectedFee = purchaseAmount * MAX_FEE_RATE / 10_000;
@@ -216,4 +240,4 @@ contract FeeHandlerTest is Test {
             assertGe(rate1, rate2, "Fee rate should decrease or stay equal with higher amounts");
         }
     }
-} 
+}

--- a/test/ai-generated/unit/FeeHandlerTest.t.sol
+++ b/test/ai-generated/unit/FeeHandlerTest.t.sol
@@ -8,6 +8,8 @@ import {IFeeHandler} from "../../../src/interfaces/IFeeHandler.sol";
 contract FeeHandlerTest is Test {
     FeeHandlerHarness feeHandler;
 
+    address constant FEE_COLLECTOR = address(0xBEEF);
+
     // Default settings used across tests
     uint256 constant MIN_FEE_RATE = 100; // 1%
     uint256 constant MAX_FEE_RATE = 200; // 2%
@@ -19,6 +21,7 @@ contract FeeHandlerTest is Test {
     event FeeHandler__MaxFeeRateSet(uint256 indexed maxFeeRate);
     event FeeHandler__PurchaseLowerBoundSet(uint256 indexed feePurchaseLowerBound);
     event FeeHandler__PurchaseUpperBoundSet(uint256 indexed feePurchaseUpperBound);
+    event FeeHandler__FeeCollectorAddressSet(address indexed feeCollector);
 
     function setUp() public {
         IFeeHandler.FeeSettings memory settings = IFeeHandler.FeeSettings({
@@ -27,7 +30,7 @@ contract FeeHandlerTest is Test {
             feePurchaseLowerBound: LOWER_BOUND,
             feePurchaseUpperBound: UPPER_BOUND
         });
-        feeHandler = new FeeHandlerHarness(settings);
+        feeHandler = new FeeHandlerHarness(FEE_COLLECTOR, settings);
     }
 
     function test_constructor_reverts_invalidRates() public {
@@ -39,7 +42,7 @@ contract FeeHandlerTest is Test {
         });
 
         vm.expectRevert(IFeeHandler.FeeHandler__MinFeeRateCannotBeHigherThanMax.selector);
-        new FeeHandlerHarness(settings);
+        new FeeHandlerHarness(FEE_COLLECTOR, settings);
     }
 
     function test_constructor_reverts_invalidBounds() public {
@@ -51,7 +54,31 @@ contract FeeHandlerTest is Test {
         });
 
         vm.expectRevert(IFeeHandler.FeeHandler__FeeLowerBoundMustBeLowerThanUpperBound.selector);
-        new FeeHandlerHarness(settings);
+        new FeeHandlerHarness(FEE_COLLECTOR, settings);
+    }
+
+    function test_constructor_reverts_zeroFeeCollector() public {
+        IFeeHandler.FeeSettings memory settings = IFeeHandler.FeeSettings({
+            minFeeRate: MIN_FEE_RATE,
+            maxFeeRate: MAX_FEE_RATE,
+            feePurchaseLowerBound: LOWER_BOUND,
+            feePurchaseUpperBound: UPPER_BOUND
+        });
+
+        vm.expectRevert(IFeeHandler.FeeHandler__InvalidFeeCollector.selector);
+        new FeeHandlerHarness(address(0), settings);
+    }
+
+    function test_constructor_reverts_maxFeeRateAboveCap() public {
+        IFeeHandler.FeeSettings memory settings = IFeeHandler.FeeSettings({
+            minFeeRate: MIN_FEE_RATE,
+            maxFeeRate: feeHandler.MAX_FEE_RATE_CAP() + 1,
+            feePurchaseLowerBound: LOWER_BOUND,
+            feePurchaseUpperBound: UPPER_BOUND
+        });
+
+        vm.expectRevert(IFeeHandler.FeeHandler__MaxFeeRateExceedsCap.selector);
+        new FeeHandlerHarness(FEE_COLLECTOR, settings);
     }
 
     function test_calculateFee_belowLowerBound() public {
@@ -219,6 +246,45 @@ contract FeeHandlerTest is Test {
         }
         assertEq(aggregatedFee, expectedAggregatedFee);
         assertEq(totalNet, expectedTotalNet);
+    }
+
+    function test_setMaxFeeRate_reverts_aboveCap() public {
+        uint256 aboveCap = feeHandler.MAX_FEE_RATE_CAP() + 1;
+        vm.expectRevert(IFeeHandler.FeeHandler__MaxFeeRateExceedsCap.selector);
+        feeHandler.setMaxFeeRate(aboveCap);
+    }
+
+    function test_setMaxFeeRate_atCap_success() public {
+        uint256 cap = feeHandler.MAX_FEE_RATE_CAP();
+        feeHandler.setMaxFeeRate(cap);
+        assertEq(feeHandler.getMaxFeeRate(), cap);
+    }
+
+    function test_setFeeRateParams_reverts_maxAboveCap() public {
+        uint256 aboveCap = feeHandler.MAX_FEE_RATE_CAP() + 1;
+        vm.expectRevert(IFeeHandler.FeeHandler__MaxFeeRateExceedsCap.selector);
+        feeHandler.setFeeRateParams(MIN_FEE_RATE, aboveCap, LOWER_BOUND, UPPER_BOUND);
+    }
+
+    function test_setFeeCollectorAddress_reverts_zero() public {
+        vm.expectRevert(IFeeHandler.FeeHandler__InvalidFeeCollector.selector);
+        feeHandler.setFeeCollectorAddress(address(0));
+    }
+
+    function test_setFeeCollectorAddress_success() public {
+        address newCollector = address(0xCAFE);
+        vm.expectEmit(true, true, true, true);
+        emit FeeHandler__FeeCollectorAddressSet(newCollector);
+        feeHandler.setFeeCollectorAddress(newCollector);
+        assertEq(feeHandler.getFeeCollectorAddress(), newCollector);
+    }
+
+    function test_getFeeSettings_matchesIndividualGetters() public {
+        IFeeHandler.FeeSettings memory settings = feeHandler.getFeeSettings();
+        assertEq(settings.minFeeRate, feeHandler.getMinFeeRate());
+        assertEq(settings.maxFeeRate, feeHandler.getMaxFeeRate());
+        assertEq(settings.feePurchaseLowerBound, feeHandler.getFeePurchaseLowerBound());
+        assertEq(settings.feePurchaseUpperBound, feeHandler.getFeePurchaseUpperBound());
     }
 
     // Test to ensure monotonicity: higher purchase amounts should have lower or equal fee rates

--- a/test/mocks/FeeHandlerHarness.sol
+++ b/test/mocks/FeeHandlerHarness.sol
@@ -11,6 +11,14 @@ contract FeeHandlerHarness is FeeHandler {
         return _calculateFee(amount);
     }
 
+    function exposedCalculateFeeAndNetAmounts(uint256[] memory purchaseAmounts)
+        external
+        view
+        returns (uint256 aggregatedFee, uint256[] memory netAmountsToSpend, uint256 totalAmountToSpend)
+    {
+        return _calculateFeeAndNetAmounts(purchaseAmounts);
+    }
+
     // Test-only setters without onlyOwner restriction for convenience
     function testSetFeeRateParams(uint256 minFee, uint256 maxFee, uint256 lower, uint256 upper) external {
         s_minFeeRate = minFee;

--- a/test/mocks/FeeHandlerHarness.sol
+++ b/test/mocks/FeeHandlerHarness.sol
@@ -5,7 +5,7 @@ import {FeeHandler} from "../../src/FeeHandler.sol";
 import {IFeeHandler} from "../../src/interfaces/IFeeHandler.sol";
 
 contract FeeHandlerHarness is FeeHandler {
-    constructor(IFeeHandler.FeeSettings memory settings) FeeHandler(address(0xBEEF), settings) {}
+    constructor(address feeCollector, IFeeHandler.FeeSettings memory settings) FeeHandler(feeCollector, settings) {}
 
     function exposedCalculateFee(uint256 amount) external view returns (uint256) {
         return _calculateFee(amount);
@@ -42,4 +42,4 @@ contract FeeHandlerHarness is FeeHandler {
     function testSetFeePurchaseUpperBound(uint256 upper) external {
         s_feePurchaseUpperBound = upper;
     }
-} 
+}


### PR DESCRIPTION
## Summary

Keeps the linear fee model. `setFeeRateParams` can raise the min/max band in one call, individual purchase-bound setters cannot invert the range, batch purchases load fee settings once, the constructor shares those pair checks, `maxFeeRate` is hard-capped at 5%, the fee collector cannot be zero, and `getFeeSettings()` exposes the four params in one view.

## Assigned relaunch task spec

- Spec: `docs/relaunch/R3-fee-handling.md`
- R-item (if any): R3, R4, R5 (PR 5)
- Stacked on: `feat/r7-dca-manager-small-fixes` ([#45](https://github.com/BitChillRSK/dca-contracts/pull/45))

## Scope / out of scope

**In scope**

- R3: write rates/bounds in `setFeeRateParams` after validating the new pair (no route through individual setters).
- R4: `setPurchaseLowerBound` / `setPurchaseUpperBound` validate against the other live bound.
- R5: `_feeSettings` + `_calculateFeeWithParams`; `_calculateFeeAndNetAmounts` loads once before the loop; `getFeeSettings()` on `IFeeHandler`.
- Constructor validation for fee settings (same pair + cap checks).
- `MAX_FEE_RATE_CAP = 500` (5%) on constructor, `setFeeRateParams`, and `setMaxFeeRate`.
- Reject `feeCollector == address(0)` in constructor and `setFeeCollectorAddress`.

**Out of scope (not in this PR)**

- Flatten to one rate or new purchase-bound product values
- R18 packing, R19 pause, R12/R13
- R6 / R17 purchase-path / `nonReentrant` work
- Event reshaping (R9)
- Handler / accounting / SIP-0094 (R1, R20)
- `forge fmt`, deploy broadcasts, `dca-out-contracts`

## Files beyond the spec

- `src/interfaces/IFeeHandler.sol` — new errors, `getFeeSettings` (named in updated spec)

## Tests run

```
forge test --match-contract FeeHandlerTest
SWAP_TYPE=mocSwaps LENDING_PROTOCOL=tropykus forge test --match-contract TropykusErc20HandlerTest --match-test modifyFeeSettings
make check
```

## ABI changes

- [ ] None
- [x] Yes — add `getFeeSettings() view returns (FeeSettings)`; add `FeeHandler__InvalidFeeCollector`, `FeeHandler__MaxFeeRateExceedsCap`; public constant getter `MAX_FEE_RATE_CAP()`. Constructor / setters reject `maxFeeRate > 500` and zero collector.

## Deployment / script impact

- [x] None
- [ ] `script/` or deploy config changed (local/test only; this PR must not broadcast)
- [x] Cutover / frontend note: owner can raise the fee band in one `setFeeRateParams` call, never above 5%. Production can keep flat `minFeeRate == maxFeeRate == 100`. Frontends may use `getFeeSettings()`.

## Security considerations

Protocol invariants in `AGENTS.md` are unchanged. Fee math is identical; additions are setter/constructor invariants, a hard rate ceiling, and a zero-collector guard.

## Reviewer checklist

- [ ] Matches the assigned spec (or is clearly not a relaunch item)
- [ ] No optional / further-review work unless the spec assigned it
- [ ] PR is small and behavior-scoped; no unrelated refactors
- [ ] Extra files beyond the spec are listed and justified
- [ ] Tests listed above were run locally
- [ ] GitHub Actions CI is green after the latest push
- [ ] Protocol invariants in `AGENTS.md` still hold unless the spec changed one
- [ ] No broadcast, live-chain interaction, or secrets in the diff
- [ ] `_calculateFeeAndNetAmounts` loop uses `_calculateFeeWithParams` with a once-loaded `FeeSettings`, not `_calculateFee`

Made with [Cursor](https://cursor.com)