### PR TITLE
test: live Sovryn SIP-0094 exit-fee probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,13 @@ FORK_TEST_CMD := forge test --no-match-test invariant --no-match-contract Compar
 # mint on a fork: block 8739512 (2026-04-16 16:20 UTC) still mints, 8740674 (2026-04-17 00:13 UTC)
 # reverts with kToken error "C2". Do not raise this past 8739512.
 FORK_BLOCK_TROPYKUS ?= 8700000
+# Live SIP-0094 probe (`make probe-sovryn-exit-fee`). Override with PROBE_VERBOSITY=-vvvv
+# or PROBE_MATCH=test_controllerFlagAndVault.
+PROBE_VERBOSITY ?= -vv
+PROBE_MATCH ?=
 
 # Targets
-.PHONY: all test moc dex help check ci build patch-deps slither moc-tropykus moc-sovryn dex-tropykus dex-sovryn fork fork-tropykus fork-sovryn coverage
+.PHONY: all test moc dex help check ci build patch-deps slither moc-tropykus moc-sovryn dex-tropykus dex-sovryn fork fork-tropykus fork-sovryn probe-sovryn-exit-fee coverage
 
 all: help
 
@@ -96,6 +100,20 @@ fork-sovryn:
 	SWAP_TYPE=$(SWAP_TYPE) LENDING_PROTOCOL=sovryn EXPECTED_LENDING_PROTOCOL=sovryn STABLECOIN_TYPE=$(STABLECOIN_TYPE) \
 	$(FORK_TEST_CMD) --fork-url $$RSK_MAINNET_RPC_URL
 
+# Live iSUSD burn probe for SIP-0094 (excluded from check/fork/CI). See
+# test/mainnet-debug/sovryn-exit-fee/README.md. PROBE_VERBOSITY=-vvvv for the burn trace.
+probe-sovryn-exit-fee:
+	@echo "Probing live Sovryn iSUSD burn for SIP-0094 exit fee..."
+	@set -a; [ -f .env ] && . ./.env; set +a; \
+	if [ -z "$$RSK_MAINNET_RPC_URL" ]; then \
+		echo "error: RSK_MAINNET_RPC_URL is not set. Add it to .env or export it."; \
+		exit 1; \
+	fi; \
+	SWAP_TYPE=mocSwaps LENDING_PROTOCOL=sovryn EXPECTED_LENDING_PROTOCOL=sovryn STABLECOIN_TYPE=DOC \
+	forge test --match-path "test/mainnet-debug/sovryn-exit-fee/**" \
+		$(if $(PROBE_MATCH),--match-test $(PROBE_MATCH),) \
+		--fork-url $$RSK_MAINNET_RPC_URL $(PROBE_VERBOSITY) -j 1
+
 # DexSwaps specific tests (DcaDappTest requires SWAP_TYPE and LENDING_PROTOCOL)
 dex:
 	@echo "Executing DexSwaps tests with $(LENDING_PROTOCOL) and $(STABLECOIN_TYPE)..."
@@ -130,6 +148,7 @@ help:
 	@echo "  make fork                      # Fork tests (reads RSK_MAINNET_RPC_URL from env/.env); tropykus pins block $(FORK_BLOCK_TROPYKUS)"
 	@echo "  make fork-tropykus             # Tropykus fork tests (pinned: kDOC mint paused 2026-04-27)"
 	@echo "  make fork-sovryn               # Sovryn fork tests (chain tip)"
+	@echo "  make probe-sovryn-exit-fee     # Live iSUSD burn: is SIP-0094's 0.1% fee charging?"
 	@echo ""
 	@echo "Environment variables:"
 	@echo "  SWAP_TYPE: mocSwaps (default) or dexSwaps"

--- a/test/mainnet-debug/sovryn-exit-fee/README.md
+++ b/test/mainnet-debug/sovryn-exit-fee/README.md
@@ -1,0 +1,41 @@
+# Sovryn SIP-0094 exit-fee probe
+
+Live Rootstock fork checks for whether Sovryn's 0.1% Perimeter Fee (SIP-0094) is **charging** on iSUSD `burn`.
+
+Not part of `make check`, `make fork-*`, or CI (`test/mainnet-debug/**`). Needs `RSK_MAINNET_RPC_URL` in `.env`.
+
+## Run
+
+```bash
+make probe-sovryn-exit-fee
+```
+
+Full `burn` trace (look for a DOC `Transfer` to the ExitFeeVault, or a call to the controller):
+
+```bash
+make probe-sovryn-exit-fee PROBE_VERBOSITY=-vvvv
+```
+
+Controller flag only (no mint/burn):
+
+```bash
+make probe-sovryn-exit-fee PROBE_MATCH=test_controllerFlagAndVault
+```
+
+## How to read it
+
+| Signal | Fee **off** (2026-08-19 tip) | Fee **on** at 10 bps |
+|---|---|---|
+| `exitFeeEnabled` | `false` | `true` |
+| `burn returned` vs DOC received | equal (maybe 1–2 wei of `tokenPrice` rounding) | received ≈ 99.9% of returned |
+| `ExitFeeVault DOC delta` | `0` | ~0.1% of the redemption |
+| `-vvvv` trace | one DOC `Transfer` to the burner; no controller call | second `Transfer` to the vault; `ExitFeeApplied` |
+
+A 0.1% fee on 1,000 DOC is **1 DOC**, not 1 wei. `sovrynProtocol.exitFeeController()` reverting `target not active` means Part 1's lending modules are not the live logic yet — the controller can exist while charging is still impossible.
+
+## Addresses (RSK mainnet)
+
+- iSUSD: `0xd8D25f03EBbA94E15Df2eD4d6D38276B595593c1`
+- ExitFeeController: `0x8C1abf364Bf214E41221562693BD9Fb26D6Fa563`
+- ExitFeeVault: `0x2ba389B021fA4A5F50cc1758EFD23Ca066d0Be08`
+- sovrynProtocol: `0x5A0D867e0D70Fcc6Ade25C3F1B89d618b5B4Eaa7`

--- a/test/mainnet-debug/sovryn-exit-fee/SovrynExitFeeProbe.t.sol
+++ b/test/mainnet-debug/sovryn-exit-fee/SovrynExitFeeProbe.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.36;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {DcaDappTest} from "../../unit/DcaDappTest.t.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IiSusdToken} from "../../../src/sovryn/IiSusdToken.sol";
+import {DOC_HOLDER} from "../../../script/Constants.sol";
+
+interface IExitFeeControllerView {
+    function exitFeeEnabled() external view returns (bool);
+    function feeReceiver() external view returns (address);
+}
+
+interface ISovrynProtocolExitFee {
+    function exitFeeController() external view returns (address);
+}
+
+/// @dev Live Rootstock fork probe for SIP-0094's 0.1% Perimeter Fee.
+/// Excluded from `make check` / `make fork-*` / CI (`test/mainnet-debug/**`).
+/// Run: `make probe-sovryn-exit-fee` (see README.md in this folder).
+contract SovrynExitFeeDirectBurnProbe is Test {
+    address constant DOC = 0xe700691dA7b9851F2F35f8b8182c69c53CcaD9Db;
+    address constant I_SUSD = 0xd8D25f03EBbA94E15Df2eD4d6D38276B595593c1;
+    address constant EXIT_FEE_CONTROLLER = 0x8C1abf364Bf214E41221562693BD9Fb26D6Fa563;
+    address constant EXIT_FEE_VAULT = 0x2ba389B021fA4A5F50cc1758EFD23Ca066d0Be08;
+    address constant SOVRYN_PROTOCOL = 0x5A0D867e0D70Fcc6Ade25C3F1B89d618b5B4Eaa7;
+    uint256 constant DEPOSIT_AMOUNT = 1000 ether;
+
+    function test_controllerFlagAndVault() external view {
+        bool enabled = IExitFeeControllerView(EXIT_FEE_CONTROLLER).exitFeeEnabled();
+        address receiver = IExitFeeControllerView(EXIT_FEE_CONTROLLER).feeReceiver();
+        uint256 vaultDoc = IERC20(DOC).balanceOf(EXIT_FEE_VAULT);
+
+        console2.log("block", block.number);
+        console2.log("exitFeeEnabled", enabled);
+        console2.log("feeReceiver", receiver);
+        console2.log("ExitFeeVault DOC balance", vaultDoc);
+
+        try ISovrynProtocolExitFee(SOVRYN_PROTOCOL).exitFeeController() returns (address ctrl) {
+            console2.log("sovrynProtocol.exitFeeController", ctrl);
+        } catch {
+            console2.log("sovrynProtocol.exitFeeController: reverted (selector not active)");
+        }
+    }
+
+    function testDirectIsusdBurn_printFeeSplit() external {
+        vm.startPrank(DOC_HOLDER);
+        IERC20(DOC).approve(I_SUSD, DEPOSIT_AMOUNT);
+        IiSusdToken(I_SUSD).mint(DOC_HOLDER, DEPOSIT_AMOUNT);
+        uint256 shares = IERC20(I_SUSD).balanceOf(DOC_HOLDER);
+
+        uint256 userDocBefore = IERC20(DOC).balanceOf(DOC_HOLDER);
+        uint256 vaultDocBefore = IERC20(DOC).balanceOf(EXIT_FEE_VAULT);
+        uint256 returned = IiSusdToken(I_SUSD).burn(DOC_HOLDER, shares);
+        uint256 received = IERC20(DOC).balanceOf(DOC_HOLDER) - userDocBefore;
+        uint256 vaultDelta = IERC20(DOC).balanceOf(EXIT_FEE_VAULT) - vaultDocBefore;
+        vm.stopPrank();
+
+        uint256 haircutBps = returned > received ? ((returned - received) * 10_000) / returned : 0;
+        console2.log("burn returned (gross)", returned);
+        console2.log("DOC received (net)", received);
+        console2.log("ExitFeeVault DOC delta", vaultDelta);
+        console2.log("haircut bps (approx)", haircutBps);
+        console2.log("10 bps of gross would be", returned / 1000);
+    }
+}
+
+/// @dev Same withdrawal the unit suite runs (`dcaManager.withdrawToken` → handler `burn`).
+/// DcaDappTest.setUp reads the MoC oracle, which currently reverts
+/// `Wrong lastPublicationBlock` on Anvil, so that one view is mocked.
+contract SovrynExitFeeWithdrawalProbe is DcaDappTest {
+    address constant EXIT_FEE_VAULT = 0x2ba389B021fA4A5F50cc1758EFD23Ca066d0Be08;
+
+    function setUp() public override {
+        vm.mockCall(MOC_ORACLE_MAINNET, abi.encodeWithSignature("getPrice()"), abi.encode(uint256(50_000e18)));
+        super.setUp();
+    }
+
+    function testStablecoinWithdrawal_printSovrynFeeSplit() external {
+        address doc = address(stablecoin);
+        address iSusd = address(lendingToken);
+        address handler = address(stablecoinHandler);
+
+        uint256 vaultDocBefore = IERC20(doc).balanceOf(EXIT_FEE_VAULT);
+        uint256 userDocBefore = IERC20(doc).balanceOf(USER);
+        uint256 iSusdBefore = IERC20(iSusd).balanceOf(handler);
+
+        super.withdrawStablecoin();
+
+        console2.log("iSUSD burned (handler)", iSusdBefore - IERC20(iSusd).balanceOf(handler));
+        console2.log("DOC paid to user", IERC20(doc).balanceOf(USER) - userDocBefore);
+        console2.log("ExitFeeVault DOC delta", IERC20(doc).balanceOf(EXIT_FEE_VAULT) - vaultDocBefore);
+        console2.log("requested withdrawal", AMOUNT_TO_DEPOSIT);
+        console2.log("10 bps of requested would be", AMOUNT_TO_DEPOSIT / 1000);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in Rootstock-fork probe so we can re-check whether SIP-0094's 0.1% iSUSD `burn` fee is charging, without waiting for it to brick the live handler or pollute `make check`.

## Assigned relaunch task spec

- Spec: n/a — not a relaunch item
- R-item (if any): none
- Stacked on: `refactor/r16-redeem-glossary` ([#55](https://github.com/BitChillRSK/dca-contracts/pull/55))

## Scope / out of scope

**In scope**

- Fork-only tests under `test/mainnet-debug/sovryn-exit-fee/` (controller flag, direct iSUSD mint/burn, BitChill `withdrawToken` path)
- `make probe-sovryn-exit-fee` and a short README for how to read the logs

**Out of scope (not in this PR)**

- Handler accounting / R1
- Any production or mock-suite behavior change

## Files beyond the spec

- n/a (not a relaunch spec)

## Tests run

```
make probe-sovryn-exit-fee
```

3 passed on the live fork (block ~9164351): `exitFeeEnabled == false`, vault delta 0, burn return equals DOC received (1–2 wei rounding).

`make check` / `make fork-sovryn` / `make fork-tropykus` are unchanged: this path is already excluded via `test/mainnet-debug/**`. Re-run the probe with `PROBE_VERBOSITY=-vvvv` to inspect the `burn` trace.

## ABI changes

- [x] None

## Deployment / script impact

- [x] None

## Security considerations

Read-only fork probe. No protocol invariants change. Does not broadcast.

## Reviewer checklist

- [ ] Matches the assigned spec (or is clearly not a relaunch item)
- [ ] No optional / further-review work unless the spec assigned it
- [ ] PR is small and behavior-scoped; no unrelated refactors
- [ ] Extra files beyond the spec are listed and justified
- [ ] Tests listed above were run locally
- [ ] GitHub Actions CI is green after the latest push
- [ ] Protocol invariants in `AGENTS.md` still hold unless the spec changed one
- [ ] No broadcast, live-chain interaction, or secrets in the diff

Made with [Cursor](https://cursor.com)