### PR TITLE
docs: define external reward forwarding boundary

### DIFF
--- a/docs/relaunch/EXTERNAL_REWARDS.md
+++ b/docs/relaunch/EXTERNAL_REWARDS.md
@@ -1,0 +1,60 @@
+# External lending rewards and forwarding
+
+Status: **decision record** (2026-08-24). Applies to the relaunch lending handlers and the R9 event/ABI pass.
+
+## Decision
+
+BitChill lending handlers distribute the lending protocol's native interest only. They do **not** claim, custody, unwrap, index, or redistribute temporary third-party incentives such as Merkl campaigns.
+
+The preferred path for a supported external campaign is off-chain reward forwarding: the campaign indexer reconstructs each BitChill user's time-weighted virtual lending-token balance and credits that user directly. This keeps reward proofs, Distributor/operator permissions, campaign-specific tokens, keepers, and reward liabilities out of immutable handler contracts.
+
+BitChill does not wait for a forwarding provider before shipping a handler. If a provider cannot or will not integrate BitChill, rewards attributed to the pooled handler position remain unclaimed. They do not become an owner fee or an approximately distributed current-holder reward. Product surfaces must describe BitChill yield as native lending yield and must not advertise an incentive-inclusive APR unless forwarding for that campaign is actually live.
+
+## Why there is no on-chain reward index
+
+A MasterChef-style index is not fair when rewards accrue off-chain and reach the handler later through an asynchronous claim. A user can hold shares while rewards are earned and exit before the claim; a new depositor present at harvest would then receive the earlier user's rewards. Updating the index only when tokens arrive allocates by shares at claim time, not shares over the earning period.
+
+Solving that mismatch on-chain would require campaign-aware historical checkpoints, claims, or another trusted allocation layer. That is a separate reward protocol, not part of a lending handler.
+
+## Indexer-ready lending-share history
+
+Future forwarding must not depend on transaction traces or on reconstructing lending-token exchange rates. Starting from the fresh relaunch deployment, an indexer must be able to replay one canonical event and recover the exact virtual lending-token balance BitChill assigns to every user after every mutation.
+
+R9 must add this shared event to `ITokenLending`:
+
+```solidity
+event TokenLending__UserSharesUpdated(
+    address indexed user,
+    uint256 previousShares,
+    uint256 newShares
+);
+```
+
+Only `user` is indexed, in line with the event-indexing rule. Block number, timestamp, transaction index, and log index already supply ordering and time; the event must not duplicate them.
+
+Every lending handler must emit the event after each successful change to its per-user virtual lending-share mapping:
+
+- a deposit, using the lending-token balance delta actually minted to the handler;
+- a normal stablecoin withdrawal;
+- an interest withdrawal;
+- a single rBTC purchase;
+- each per-user debit in a batch purchase, including sequential updates when the same user appears more than once.
+
+`previousShares` lets an indexer detect a missed or inconsistent transition. `newShares` is the canonical post-state and must equal `getUsersLendingTokenBalance(user)` after the transaction. Reverted mutations produce no lasting event.
+
+No new on-chain `totalShares` counter is required for forwarding. An indexer can sum the latest per-user balances from the event stream and cross-check individual balances through the existing getter. The lending token's `balanceOf(handler)` remains an independent aggregate solvency check, subject to the handler's documented rounding behavior.
+
+## Existing events are not a substitute
+
+- `TokenHandler__TokenDeposited` identifies the user but reports stablecoin received, not the exact number of lending shares minted at the then-current exchange rate.
+- `TokenLending__LendingTokenRedeemed` reports exact per-user share burns, including batch debits, but there is no corresponding exact share-mint event.
+- `DcaManager` events report schedule principal in underlying stablecoin. Schedule principal is not a lending-share balance.
+- `getUsersLendingTokenBalance(user)` exposes current state, not the historical time-weighted balance required for forwarding.
+
+R9 therefore owns the canonical balance-transition event in addition to correcting which existing event fields are indexed. Merely removing `indexed` from numeric fields is not enough.
+
+## Scope boundaries
+
+- R22 LayerBank implements lending and per-user share accounting only. It does not add Merkl interfaces, proofs, Distributor calls, operators, reward tokens, harvest functions, reward debt, or WRBTC unwrapping.
+- R9 adds the protocol-neutral event across the shipped lending handlers and tests every share-changing path. It does not add an external-reward integration.
+- A future forwarding provider may consume the event and getter without requiring a handler upgrade. Provider-specific API or campaign work stays off-chain.

--- a/docs/relaunch/IMPLEMENTATION_ORDER.md
+++ b/docs/relaunch/IMPLEMENTATION_ORDER.md
@@ -26,6 +26,12 @@ Record these **before the first PR that changes fee logic, `DcaDetails`, handler
 
 Defaults if the human says “use defaults”: keep OZ `v4.9.3`; skip packing (still `calldata` on handler batch arrays); defer R12, R13, R19, owner sweep, deposit pause. Do not apply defaults unless they say so.
 
+## External lending incentives
+
+The relaunch handlers distribute native lending interest only. They do not claim or redistribute temporary third-party incentives. Future campaign support should use off-chain forwarding directly to users; if a provider does not integrate BitChill, the handler leaves those rewards unclaimed rather than adding an approximate harvest-time allocation or an owner claim. Frontends must not present an incentive-inclusive APR as BitChill yield unless forwarding is live.
+
+This does **not** depend on a provider response. R9 must make the handlers indexer-ready by emitting one canonical per-user virtual lending-share balance transition after every share mint or burn. See [`EXTERNAL_REWARDS.md`](./EXTERNAL_REWARDS.md) for the decided event shape, required emit sites, and scope boundary.
+
 ## PR order
 
 Ask = product questions for that PR only. `Start with R2` means PR 3.
@@ -186,6 +192,8 @@ This should land before the full natspec pass (R10).
 
 Add LayerBank as index 1 for DOC + MoC. Use balance-delta accounting from the start (including R21 deposit returns). Add mocks or fork tests based on the Rootstock LayerBank lToken ABI.
 
+LayerBank owns exact per-user virtual lToken balances and implements the shared `getUsersLendingTokenBalance(user)` getter. External incentives are out of scope: no Merkl interfaces, reward token, harvest, claim, operator, reward-debt, or unwrap logic. R9 later adds the canonical balance-transition event across the final lending-handler set; LayerBank must expose every share mutation cleanly enough for that event to cover deposits, withdrawals, interest, and single/batch purchases. See [`EXTERNAL_REWARDS.md`](./EXTERNAL_REWARDS.md).
+
 Do not rename Tropykus in place and do not deploy USDRIF/Uniswap handlers for this relaunch.
 
 ### PR 16 - R22 deploy scripts, constants, harness, and CI matrix
@@ -202,6 +210,8 @@ Split the shared test harness so lending-token assertions live only in lending-p
 ### PR 17 - R9 event indexing and ABI cleanup
 
 Index only addresses and `scheduleId`. Do not index amounts, timestamps, periods, rates, strings, bytes, or arrays.
+
+Add `TokenLending__UserSharesUpdated(address indexed user, uint256 previousShares, uint256 newShares)` to the shared lending interface and emit it after every successful per-user virtual lending-share mutation in the shipped lending handlers. Deposits report the exact measured lending-token mint, not the stablecoin input. Withdrawals, interest, single purchases, and every buyer debit in a batch are covered; repeated users in one batch produce sequential transitions. Tests must show each `newShares` equals `getUsersLendingTokenBalance(user)` and that replay from the fresh deployment reconstructs current balances. This is protocol observability for possible off-chain forwarding, not an on-chain external-reward integration. See [`EXTERNAL_REWARDS.md`](./EXTERNAL_REWARDS.md).
 
 Do this once the shipped ABI surface is known, including any optional pause or compound-interest events that were approved.
 

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -18,6 +18,10 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 3. Optional/further-review items get a spec only when explicitly assigned.
 4. One spec = one PR unless **Scope** names a tight bundle.
 
+## Decision records
+
+- [`EXTERNAL_REWARDS.md`](./EXTERNAL_REWARDS.md) — lending handlers distribute native protocol interest only; external campaigns use off-chain forwarding if available. R9 must add a canonical per-user lending-share balance-transition event so forwarding does not depend on transaction traces or a provider response.
+
 ## Status
 
 - Merged: [R23-toolchain-baseline.md](./R23-toolchain-baseline.md) (PR 1, GitHub [#42](https://github.com/BitChillRSK/dca-contracts/pull/42)). Rootstock testnet accepted solc 0.8.36 / `cancun`.

--- a/docs/relaunch/README.md
+++ b/docs/relaunch/README.md
@@ -20,7 +20,7 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 
 ## Decision records
 
-- [`EXTERNAL_REWARDS.md`](./EXTERNAL_REWARDS.md) — lending handlers distribute native protocol interest only; external campaigns use off-chain forwarding if available. R9 must add a canonical per-user lending-share balance-transition event so forwarding does not depend on transaction traces or a provider response.
+- [`EXTERNAL_REWARDS.md`](./EXTERNAL_REWARDS.md) (GitHub [#57](https://github.com/BitChillRSK/dca-contracts/pull/57)) — lending handlers distribute native protocol interest only; external campaigns use off-chain forwarding if available. R9 must add a canonical per-user lending-share balance-transition event so forwarding does not depend on transaction traces or a provider response.
 
 ## Status
 
@@ -37,4 +37,5 @@ Document any extra files in the PR. Do not search `out/`, `cache/`, or `lib/`. D
 - Assigned: [R22-idle-handler.md](./R22-idle-handler.md) (PR 12, GitHub [#53](https://github.com/BitChillRSK/dca-contracts/pull/53)). Idle DOC + MoC handler at index 0. No product gates. Stacked on [#52](https://github.com/BitChillRSK/dca-contracts/pull/52).
 - Assigned: [R21-fee-on-transfer-deposits.md](./R21-fee-on-transfer-deposits.md) (PR 13, GitHub [#54](https://github.com/BitChillRSK/dca-contracts/pull/54)). Hop-1 received-on-deposit. FOT unsupported; withdraw still works if a listed token turns on a fee. No product gates. Stacked on [#53](https://github.com/BitChillRSK/dca-contracts/pull/53).
 - Assigned: [R16-redeem-glossary.md](./R16-redeem-glossary.md) (PR 14, GitHub [#55](https://github.com/BitChillRSK/dca-contracts/pull/55)). Rename-only; first-party "redeem" now names the asset given up. Keeps PR 13's 1-wei batch-redemption event check. No product gates. Stacked on [#54](https://github.com/BitChillRSK/dca-contracts/pull/54).
-- Next unassigned: `Start with R22 (LayerBank)` (PR 15). No product gates. Handler-replacement in `OperationsAdmin` stays unassigned (later). PR 2 (decision record) stays available when the human wants to record R18 / R19 / optionals.
+- Supporting: [EXTERNAL_REWARDS.md](./EXTERNAL_REWARDS.md) (GitHub [#57](https://github.com/BitChillRSK/dca-contracts/pull/57)). Docs-only external-incentive boundary and indexer-ready R9 share-event requirement. Stacked on the live Sovryn probe [#56](https://github.com/BitChillRSK/dca-contracts/pull/56); no Solidity or ABI change in this PR.
+- Next unassigned: `Start with R22 (LayerBank)` (PR 15). No product gates. Stack on [#57](https://github.com/BitChillRSK/dca-contracts/pull/57). Handler-replacement in `OperationsAdmin` stays unassigned (later). PR 2 (decision record) stays available when the human wants to record R18 / R19 / optionals.


### PR DESCRIPTION
## Summary

Records the pre-LayerBank external-reward decision: relaunch handlers expose native lending yield only, external campaigns use off-chain forwarding if available, and unsupported rewards remain unclaimed. It also makes R9 responsible for a canonical per-user lending-share balance-transition event so a future indexer can reconstruct exact historical balances without transaction traces or a provider response.

## Assigned relaunch task spec

- Spec: `docs/relaunch/EXTERNAL_REWARDS.md` — docs-only decision record
- R-item (if any): informs R22 LayerBank and expands the committed R9 event/ABI scope
- Stacked on: `test/sovryn-exit-fee-probe` ([#56](https://github.com/BitChillRSK/dca-contracts/pull/56))

## Scope / out of scope

**In scope**

- Record that handlers do not claim, custody, or redistribute Merkl or other temporary external incentives
- Require `TokenLending__UserSharesUpdated(user, previousShares, newShares)` in R9
- Define the share-changing paths and replay/cross-check requirements that R9 must test
- Keep LayerBank unblocked and provider-independent

**Out of scope (not in this PR)**

- Solidity, interfaces, tests, deploy scripts, or ABI changes
- Any Merkl proof, Distributor, operator, keeper, reward-token, harvest, or unwrap integration
- The LayerBank handler implementation

## Files beyond the spec

- `docs/relaunch/IMPLEMENTATION_ORDER.md` — applies the decision to R22 LayerBank and R9
- `docs/relaunch/README.md` — links the decision record

## Tests run

```
git diff --check
make check
make fork-sovryn
make fork-tropykus
```

All passed. The first sandboxed `make check` attempt hit Foundry's macOS system-proxy/cache panic before tests began; the required rerun outside the sandbox passed.

## ABI changes

- [x] None — documentation only; the event ABI change is assigned to future R9

## Deployment / script impact

- [x] None
- [x] Cutover / frontend note: do not advertise incentive-inclusive APR as BitChill yield unless forwarding is live

## Security considerations

No contract behavior or protocol invariant changes. The decision avoids adding asynchronous reward liabilities and approximate harvest-time allocation to immutable lending handlers.

## Reviewer checklist

- [ ] Matches the assigned spec (or is clearly not a relaunch item)
- [ ] No optional / further-review work unless the spec assigned it
- [ ] PR is small and behavior-scoped; no unrelated refactors
- [ ] Extra files beyond the spec are listed and justified
- [ ] Tests listed above were run locally
- [ ] GitHub Actions CI is green after the latest push
- [ ] Protocol invariants in `AGENTS.md` still hold unless the spec changed one
- [ ] No broadcast, live-chain interaction, or secrets in the diff
